### PR TITLE
Support more number format options

### DIFF
--- a/rupypy/lexer.py
+++ b/rupypy/lexer.py
@@ -283,6 +283,10 @@ class Lexer(object):
         elif ch.isdigit():
             self.add(ch)
             return "NUMBER"
+        elif ch == "_":
+            if not self.peek().isdigit():
+                raise LexerError(self.current_pos())
+            return "NUMBER"
         else:
             self.emit("NUMBER")
             return self.handle_generic(ch)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,6 +11,9 @@ class TestParser(BaseRuPyPyTest):
         assert ec.space.parse(ec, "-1") == ast.Main(ast.Block([
             ast.Statement(ast.ConstantInt(-1))
         ]))
+        assert ec.space.parse(ec, "1_1") == ast.Main(ast.Block([
+            ast.Statement(ast.ConstantInt(11))
+        ]))
 
     def test_float(self, ec):
         assert ec.space.parse(ec, "0.2") == ast.Main(ast.Block([


### PR DESCRIPTION
There's a variety of ways to write literal numbers in Ruby. Start supporting them.
