### PR TITLE
Add RubyHash based on Python dict

### DIFF
--- a/rupypy/objects/floatobject.py
+++ b/rupypy/objects/floatobject.py
@@ -13,6 +13,15 @@ class W_FloatObject(W_BaseObject):
     def float_w(self, space):
         return self.floatvalue
 
+    def __eq__(self, other):
+        return type(self) == type(other) and self.__hash__() == other.__hash__()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return self.floatvalue.__hash__()
+
     @classdef.method("to_s")
     def method_to_s(self, space):
         return space.newstr_fromstr(str(self.floatvalue))

--- a/rupypy/objects/hashobject.py
+++ b/rupypy/objects/hashobject.py
@@ -1,5 +1,65 @@
+from rupypy.module import ClassDef
+from rupypy.modules.enumerable import Enumerable
 from rupypy.objects.objectobject import W_BaseObject
-
+from rupypy.objects.rangeobject import W_RangeObject
 
 class W_HashObject(W_BaseObject):
-    pass
+    classdef = ClassDef("Hash", W_BaseObject.classdef)
+    classdef.include_module(Enumerable)
+
+    def __init__(self, dict_w = None):
+        if dict_w is None:
+            self.dict_w = dict()
+        else:
+            self.dict_w = dict_w
+
+    classdef.app_method("""
+    def to_s()
+        result = "{"
+        i = 0
+        self.each_with_index do |obj, i|
+            if i > 0
+                result << ", "
+            end
+            result << obj[0].to_s << " => " << obj[1].to_s
+        end
+        result << "}"
+    end
+    """)
+
+    @classdef.method("[]")
+    def method_at(self, space, w_key):
+        return self.dict_w.get(w_key, space.w_nil)
+
+    @classdef.method("[]=")
+    def method_at_put(self, space, w_key, w_obj):
+        self.dict_w[w_key] = w_obj
+        return w_obj
+
+    @classdef.method("size")
+    @classdef.method("length")
+    def method_length(self, space):
+        return space.newint(len(self.dict_w))
+
+    @classdef.method("keys")
+    def method_keys(self, space):
+        return space.newarray(self.dict_w.keys())
+
+    @classdef.method("values")
+    def method_values(self, space):
+        return space.newarray(self.dict_w.values())
+
+    @classdef.method("length")
+    def method_length(self, space):
+        return space.newint(len(self.dict_w))
+
+    classdef.app_method("""
+    def each
+        i = 0
+        k = self.keys
+        while i < self.length
+            yield *[k[i], self[k[i]]]
+            i += 1
+        end
+    end
+    """)

--- a/rupypy/objects/intobject.py
+++ b/rupypy/objects/intobject.py
@@ -18,6 +18,15 @@ class W_IntObject(W_BaseObject):
     def float_w(self, space):
         return float(self.intvalue)
 
+    def __eq__(self, other):
+        return type(self) == type(other) and self.__hash__() == other.__hash__()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return self.intvalue.__hash__()
+
     @classdef.method("to_s")
     def method_to_s(self, space):
         return space.newstr_fromstr(str(self.intvalue))

--- a/rupypy/objects/stringobject.py
+++ b/rupypy/objects/stringobject.py
@@ -60,6 +60,15 @@ class W_StringObject(W_BaseObject):
         self.storage = storage
         self.strategy = strategy
 
+    def __eq__(self, other):
+        return type(self) == type(other) and self.__hash__() == other.__hash__()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return self.strategy.str_w(self.storage).__hash__()
+
     @staticmethod
     def newstr_fromstr(space, strvalue):
         strategy = space.fromcache(ConstantStringStrategy)

--- a/rupypy/objects/symbolobject.py
+++ b/rupypy/objects/symbolobject.py
@@ -8,6 +8,15 @@ class W_SymbolObject(W_BaseObject):
     def __init__(self, symbol):
         self.symbol = symbol
 
+    def __eq__(self, other):
+        return type(self) == type(other) and self.__hash__() == other.__hash__()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return self.symbol.__hash__()
+
     def symbol_w(self, space):
         return self.symbol
 

--- a/tests/objects/test_hashobject.py
+++ b/tests/objects/test_hashobject.py
@@ -1,0 +1,46 @@
+from ..base import BaseRuPyPyTest
+
+
+class TestHashObject(BaseRuPyPyTest):
+    def test_to_s(self, ec):
+        w_res = ec.space.execute(ec, "return {}.to_s")
+        assert ec.space.str_w(w_res) == "{}"
+
+        w_res = ec.space.execute(ec, "return {1 => 2}.to_s")
+        assert ec.space.str_w(w_res) == "{1 => 2}"
+
+        w_res = ec.space.execute(ec, "return {1 => 2, 3 => 4}.to_s")
+        assert ec.space.str_w(w_res) == "{1 => 2, 3 => 4}"
+
+    def test_at(self, ec):
+        w_res = ec.space.execute(ec, "return {1 => 2}[1]")
+        assert ec.space.int_w(w_res) == 2
+
+        w_res = ec.space.execute(ec, "return {'a' => 2}['a']")
+        assert ec.space.int_w(w_res) == 2
+
+        w_res = ec.space.execute(ec, "return {:a => 2}[:a]")
+        assert ec.space.int_w(w_res) == 2
+
+        w_res = ec.space.execute(ec, "return {1.1 => 2}[1.1]")
+        assert ec.space.int_w(w_res) == 2
+
+    def test_at_put(self, ec):
+        w_res = ec.space.execute(ec, "return [1, 2, 3, 4, 5].at(2)")
+        assert ec.space.int_w(w_res) == 3
+
+    def test_length(self, ec):
+        w_res = ec.space.execute(ec, "return {1 => 2, 3 => 4}.length")
+        assert ec.space.int_w(w_res) == 2
+
+    def test_size(self, ec):
+        w_res = ec.space.execute(ec, "return {1 => 2, 3 => 4}.size")
+        assert ec.space.int_w(w_res) == 2
+
+    def test_keys(self, ec):
+        w_res = ec.space.execute(ec, "return {1 => 2, 3 => 4}.keys")
+        assert [ec.space.int_w(i) for i in ec.space.listview(w_res)] == [1, 3]
+
+    def test_values(self, ec):
+        w_res = ec.space.execute(ec, "return {1 => 2, 3 => 4}.values")
+        assert [ec.space.int_w(i) for i in ec.space.listview(w_res)] == [2, 4]

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -247,11 +247,11 @@ class TestCompiler(object):
     def test_comparison(self, ec):
         self.assert_compiles(ec, "1 == 1", """
         LOAD_CONST 0
-        LOAD_CONST 1
-        SEND 2 1
+        LOAD_CONST 0
+        SEND 1 1
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
 
@@ -354,17 +354,17 @@ class TestCompiler(object):
         bc = self.assert_compiles(ec, "def f() end", """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
 
-        self.assert_compiled(bc.consts_w[2], """
+        self.assert_compiled(bc.consts_w[1], """
         LOAD_CONST 0
         RETURN
         """)
@@ -372,17 +372,17 @@ class TestCompiler(object):
         bc = self.assert_compiles(ec, "def f(a, b) a + b end", """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
 
-        self.assert_compiled(bc.consts_w[2], """
+        self.assert_compiled(bc.consts_w[1], """
         LOAD_LOCAL 0
         LOAD_LOCAL 1
         SEND 0 1
@@ -445,17 +445,17 @@ class TestCompiler(object):
         self.assert_compiled(bc.consts_w[2], """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
 
-        self.assert_compiled(bc.consts_w[2].consts_w[2], """
+        self.assert_compiled(bc.consts_w[2].consts_w[1], """
         LOAD_CONST 0
         RETURN
         """)
@@ -570,24 +570,24 @@ class TestCompiler(object):
         """, """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
 
-        self.assert_compiled(bc.consts_w[2], """
+        self.assert_compiled(bc.consts_w[1], """
         YIELD 0
         DISCARD_TOP
         LOAD_CONST 0
         YIELD 1
         DISCARD_TOP
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         YIELD 2
         RETURN
         """)
@@ -685,16 +685,16 @@ class TestCompiler(object):
         """, """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
-        self.assert_compiled(bc.consts_w[2], """
+        self.assert_compiled(bc.consts_w[1], """
         LOAD_SELF
         LOAD_CONST 0
         LOAD_CLOSURE 0
@@ -705,7 +705,7 @@ class TestCompiler(object):
         LOAD_CONST 2
         LOAD_CLOSURE 0
         BUILD_BLOCK 1
-        SEND_BLOCK 3 1
+        SEND_BLOCK 1 1
         RETURN
         """)
 
@@ -734,23 +734,23 @@ class TestCompiler(object):
         """, """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
         LOAD_SELF
         BUILD_ARRAY 0
-        LOAD_CONST 3
-        SEND 4 2
+        LOAD_CONST 2
+        SEND 0 2
         DISCARD_TOP
 
-        LOAD_CONST 5
+        LOAD_CONST 3
         RETURN
         """)
 
-        self.assert_compiled(bc.consts_w[2], """
+        self.assert_compiled(bc.consts_w[1], """
         LOAD_LOCAL 0
         LOAD_CONST 0
         LOAD_CLOSURE 0
@@ -760,7 +760,7 @@ class TestCompiler(object):
         LOAD_DEREF 0
         RETURN
         """)
-        self.assert_compiled(bc.consts_w[2].consts_w[0], """
+        self.assert_compiled(bc.consts_w[1].consts_w[0], """
         LOAD_DEREF 0
         LOAD_LOCAL 0
         SEND 0 1
@@ -808,10 +808,10 @@ class TestCompiler(object):
         LOAD_INSTANCE_VAR 0
         LOAD_CONST 1
         SEND 2 1
-        STORE_INSTANCE_VAR 3
+        STORE_INSTANCE_VAR 0
         DISCARD_TOP
 
-        LOAD_CONST 4
+        LOAD_CONST 3
         RETURN
         """)
 
@@ -828,35 +828,35 @@ class TestCompiler(object):
         STORE_DEREF 0
         DISCARD_TOP
 
-        LOAD_CONST 1
+        LOAD_CONST 0
         STORE_DEREF 1
         DISCARD_TOP
 
-        LOAD_CONST 2
+        LOAD_CONST 0
         STORE_DEREF 2
         DISCARD_TOP
 
         BUILD_ARRAY 0
-        LOAD_CONST 3
+        LOAD_CONST 1
         LOAD_CLOSURE 2
         LOAD_CLOSURE 1
         LOAD_CLOSURE 0
         BUILD_BLOCK 3
-        SEND_BLOCK 4 1
+        SEND_BLOCK 2 1
         DISCARD_TOP
 
-        LOAD_CONST 5
+        LOAD_CONST 3
         RETURN
         """)
 
-        self.assert_compiled(bc.consts_w[3], """
+        self.assert_compiled(bc.consts_w[1], """
         LOAD_DEREF 0
         LOAD_DEREF 1
         LOAD_DEREF 2
         LOAD_LOCAL 0
         SEND 0 1
-        SEND 1 1
-        SEND 2 1
+        SEND 0 1
+        SEND 0 1
         RETURN
         """)
 
@@ -985,15 +985,15 @@ class TestCompiler(object):
         DISCARD_TOP
 
         LOAD_SELF
-        SEND 3 0
+        SEND 0 0
         DUP_TOP
-        LOAD_CONSTANT 4
-        LOAD_CONST 5
-        SEND 6 1
-        STORE_CONSTANT 7
+        LOAD_CONSTANT 2
+        LOAD_CONST 3
+        SEND 4 1
+        STORE_CONSTANT 2
         DISCARD_TOP
 
-        LOAD_CONST 8
+        LOAD_CONST 5
         RETURN
         """)
 
@@ -1015,17 +1015,17 @@ class TestCompiler(object):
         """, """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
 
-        self.assert_compiled(bc.consts_w[2], """
+        self.assert_compiled(bc.consts_w[1], """
         LOAD_LOCAL 0
         LOAD_LOCAL 1
         LOAD_LOCAL 2
@@ -1033,11 +1033,11 @@ class TestCompiler(object):
         RETURN
         """)
 
-        self.assert_compiled(bc.consts_w[2].defaults[0], """
+        self.assert_compiled(bc.consts_w[1].defaults[0], """
         LOAD_CONST 0
         RETURN
         """)
-        self.assert_compiled(bc.consts_w[2].defaults[1], """
+        self.assert_compiled(bc.consts_w[1].defaults[1], """
         LOAD_LOCAL 1
         RETURN
         """)
@@ -1160,17 +1160,17 @@ class TestCompiler(object):
         """, """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
 
-        w_code = bc.consts_w[2]
+        w_code = bc.consts_w[1]
         assert w_code.locals == ["a", "b"]
         assert w_code.block_arg_pos == 1
         assert w_code.block_arg_loc == w_code.LOCAL
@@ -1212,12 +1212,12 @@ class TestCompiler(object):
         SEND 3 0
         COERCE_ARRAY
         SEND 4 1
-        SEND 5 1
-        SEND 6 1
-        SEND_SPLAT 7
+        SEND 4 1
+        SEND 4 1
+        SEND_SPLAT 5
         DISCARD_TOP
 
-        LOAD_CONST 8
+        LOAD_CONST 6
         RETURN
         """)
 
@@ -1247,13 +1247,13 @@ class TestCompiler(object):
         LOAD_SCOPE
         LOAD_CONSTANT 0
         LOAD_CONST 1
+        LOAD_CONST 1
         LOAD_CONST 2
-        LOAD_CONST 3
         BUILD_FUNCTION
         ATTACH_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 4
+        LOAD_CONST 3
         RETURN
         """)
 
@@ -1264,16 +1264,16 @@ class TestCompiler(object):
         """, """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
-        assert bc.consts_w[2].max_stackdepth == 2
+        assert bc.consts_w[1].max_stackdepth == 2
 
     def test_global_variable(self, ec):
         self.assert_compiles(ec, """
@@ -1284,15 +1284,15 @@ class TestCompiler(object):
         LOAD_CONST 0
         STORE_GLOBAL 1
         DISCARD_TOP
-        LOAD_GLOBAL 2
+        LOAD_GLOBAL 1
         DISCARD_TOP
-        LOAD_GLOBAL 3
-        LOAD_CONST 4
-        SEND 5 1
-        STORE_GLOBAL 6
+        LOAD_GLOBAL 1
+        LOAD_CONST 2
+        SEND 3 1
+        STORE_GLOBAL 1
         DISCARD_TOP
 
-        LOAD_CONST 7
+        LOAD_CONST 4
         RETURN
         """)
 
@@ -1319,16 +1319,16 @@ class TestCompiler(object):
         """, """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
-        self.assert_compiled(bc.consts_w[2], """
+        self.assert_compiled(bc.consts_w[1], """
         LOAD_LOCAL 0
         RETURN
         """)
@@ -1340,16 +1340,16 @@ class TestCompiler(object):
         """, """
         LOAD_SCOPE
         LOAD_CONST 0
+        LOAD_CONST 0
         LOAD_CONST 1
-        LOAD_CONST 2
         BUILD_FUNCTION
         DEFINE_FUNCTION
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
-        self.assert_compiled(bc.consts_w[2], """
+        self.assert_compiled(bc.consts_w[1], """
         LOAD_SELF
         LOAD_CONST 0
         LOAD_CLOSURE 0
@@ -1435,11 +1435,11 @@ class TestCompiler(object):
         LOAD_CONST 2
         SEND 3 1
         BUILD_ARRAY 1
-        SEND 4 1
-        SEND_SPLAT 5
+        SEND 3 1
+        SEND_SPLAT 4
         DISCARD_TOP
 
-        LOAD_CONST 6
+        LOAD_CONST 5
         RETURN
         """)
 
@@ -1462,16 +1462,16 @@ class TestCompiler(object):
         JUMP 41
         DUP_TOP
         LOAD_SELF
-        SEND 3 1
+        SEND 1 1
         JUMP_IF_FALSE 37
         DISCARD_TOP
-        LOAD_CONST 4
+        LOAD_CONST 3
         JUMP 41
         DISCARD_TOP
-        LOAD_CONST 5
+        LOAD_CONST 4
         DISCARD_TOP
 
-        LOAD_CONST 6
+        LOAD_CONST 5
         RETURN
         """)
 
@@ -1505,11 +1505,11 @@ class TestCompiler(object):
         DUP_TOP
         LOAD_CONST 3
         LOAD_CONST 4
-        SEND 5 2
+        SEND 2 2
         DISCARD_TOP
         DISCARD_TOP
 
-        LOAD_CONST 6
+        LOAD_CONST 5
         RETURN
         """)
 
@@ -1522,10 +1522,10 @@ class TestCompiler(object):
         JUMP_IF_TRUE 13
         DISCARD_TOP
         LOAD_CONST 1
-        STORE_INSTANCE_VAR 2
+        STORE_INSTANCE_VAR 0
         DISCARD_TOP
 
-        LOAD_CONST 3
+        LOAD_CONST 2
         RETURN
         """)
 


### PR DESCRIPTION
This might not be ideal, because dict is more limited with its keys, but I don't know enough about Python to be sure. This works for now, and might work for arbitrary objects if we get stable object_ids.

**Note**: This commit adds `__eq__`, `__ne__`, and `__hash__` methods to Int, Float, String, and Symbol objects, which affects the bytecode.
