### PR TITLE
parse strings that escape the string delimiters

### DIFF
--- a/rupypy/lexer.py
+++ b/rupypy/lexer.py
@@ -699,6 +699,8 @@ class StringLexer(BaseLexer):
             if ch == self.lexer.EOF:
                 self.unread()
                 return self.tokens
+            elif ch == "\\" and self.peek() in [self.begin, self.end]:
+                self.add(self.read())
             elif ch == self.begin and (self.begin != self.end):
                 self.nesting += 1
                 self.add(ch)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -546,6 +546,7 @@ class TestParser(BaseRuPyPyTest):
             ast.Block([ast.Statement(ast.Variable("nil", 1))]),
             ast.Block([]),
         ))
+        assert ec.space.parse(ec, '"\\""') == dyn_string(ast.ConstantString('"'))
 
     def test_percent_terms(self, ec):
         dyn_string = lambda *components: ast.Main(ast.Block([
@@ -563,6 +564,8 @@ class TestParser(BaseRuPyPyTest):
         assert ec.space.parse(ec, '%<<>>') == dyn_string(ast.ConstantString("<>"))
         assert ec.space.parse(ec, '%(())') == dyn_string(ast.ConstantString("()"))
         assert ec.space.parse(ec, '%q{#{2}}') == dyn_string(ast.ConstantString("#{2}"))
+        assert ec.space.parse(ec, '%{\\{}') == dyn_string(ast.ConstantString('{'))
+        assert ec.space.parse(ec, '%{\\}}') == dyn_string(ast.ConstantString('}'))
 
     def test_class(self, ec):
         r = ec.space.parse(ec, """


### PR DESCRIPTION
Fixes parsing of mspec/lib/mkspec.rb
