### PR TITLE
Singleton methods on classes/module's don't have the correct constants

### DIFF
--- a/rupypy/objects/functionobject.py
+++ b/rupypy/objects/functionobject.py
@@ -20,7 +20,7 @@ class W_UserFunction(W_FunctionObject):
         frame = space.create_frame(
             self.bytecode,
             w_self=w_receiver,
-            w_scope=space.getclass(w_receiver),
+            w_scope=space.getscope(w_receiver),
             block=block,
         )
         with space.getexecutioncontext().visit_frame(frame):

--- a/rupypy/objspace.py
+++ b/rupypy/objspace.py
@@ -249,6 +249,12 @@ class ObjectSpace(object):
     def getsingletonclass(self, w_receiver):
         return w_receiver.getsingletonclass(self)
 
+    def getscope(self, w_receiver):
+        if isinstance(w_receiver, W_ModuleObject):
+            return w_receiver
+        else:
+            return self.getclass(w_receiver)
+
     @jit.unroll_safe
     def getnonsingletonclass(self, w_receiver):
         cls = self.getclass(w_receiver)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -334,6 +334,16 @@ class TestInterpreter(BaseRuPyPyTest):
         return X::Constant
         """)
         assert space.int_w(w_res) == 3
+        w_res = space.execute("""
+        class X
+            Constant = 3
+            def self.constant
+               Constant
+            end
+        end
+        return X.constant
+        """)
+        assert space.int_w(w_res) == 3
 
     def test___FILE__(self, space):
         w_res = space.execute("return __FILE__")
@@ -583,7 +593,6 @@ class TestInterpreter(BaseRuPyPyTest):
         """)
         assert self.unwrap(space, w_res) == ["B", "A overrides all"]
 
-    @py.test.mark.xfail
     def test_class_variables_accessed_from_class_side(self, space):
         w_res = space.execute("""
         class A; @@foo = 'A'; end


### PR DESCRIPTION
Consider:

``` ruby

module X
    CONST = 5
    def self.m
        CONST
    end
end
puts X.m
```

We currently error out on missing `CONST`, whereas printing `5` is the correct behavior.
