### PR TITLE
Redefinition of classes has wrong scoping

### DIFF
--- a/rupypy/interpreter.py
+++ b/rupypy/interpreter.py
@@ -256,7 +256,7 @@ class Interpreter(object):
         w_scope = frame.pop()
 
         name = space.symbol_w(w_name)
-        w_cls = w_scope.find_const(space, name)
+        w_cls = w_scope.find_local_const(self, name)
         if w_cls is None:
             if superclass is space.w_nil:
                 superclass = space.w_object

--- a/rupypy/objects/moduleobject.py
+++ b/rupypy/objects/moduleobject.py
@@ -133,6 +133,9 @@ class W_ModuleObject(W_RootObject):
             return self.superclass.find_inherited_const(space, name)
         return res
 
+    def find_local_const(self, space, name):
+        return self._find_const_pure(name, self.version)
+
     @jit.elidable
     def _find_const_pure(self, name, version):
         return self.constants_w.get(name, None)

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -150,6 +150,18 @@ class TestInterpreter(BaseRuPyPyTest):
         w_cls = space.w_object.constants_w["X"]
         assert w_cls.methods_w.viewkeys() == {"m", "f"}
 
+    def test_shadow_class(self, space):
+        w_res = space.execute("""
+        class X; class Y; end; end
+
+        class A < X
+          OLD_Y = Y
+          class Y; end
+        end
+        return A::OLD_Y.object_id == A::Y.object_id, A::OLD_Y.object_id == X::Y.object_id
+        """)
+        assert self.unwrap(space, w_res) == [False, True]
+
     def test_singleton_class(self, space):
         w_res = space.execute("""
         class X


### PR DESCRIPTION
```
class X
  class Y
  end
end

class A < X
  module M; end

  include M

  puts Y.object_id
  class Y < X::Y
    puts self.object_id
    include M
  end
  puts Y.object_id
end
```

We see that A has access to a constant Y from X, and try to reopen that class. Instead, we should create a new class in this case that shadows X::Y in A's scope
