### PR TITLE
block argument handling wrong for too few arguments

### DIFF
--- a/rupypy/frame.py
+++ b/rupypy/frame.py
@@ -42,6 +42,12 @@ class Frame(BaseFrame):
         elif loc == bytecode.CELL:
             self.cells[pos].set(w_value)
 
+    def handle_block_args(self, space, bytecode, args_w, block):
+        minargc = len(bytecode.arg_locs) - len(bytecode.defaults)
+        if len(args_w) < minargc:
+            args_w.extend([space.w_nil] * (minargc - len(args_w)))
+        return self.handle_args(space, bytecode, args_w, block)
+
     @jit.unroll_safe
     def handle_args(self, space, bytecode, args_w, block):
         from rupypy.interpreter import Interpreter

--- a/rupypy/objspace.py
+++ b/rupypy/objspace.py
@@ -388,7 +388,7 @@ class ObjectSpace(object):
             assert isinstance(w_arg, W_ArrayObject)
             args_w = w_arg.items_w
         if len(bc.arg_locs) != 0:
-            frame.handle_args(self, bc, args_w, None)
+            frame.handle_block_args(self, bc, args_w, None)
         assert len(block.cells) == len(bc.freevars)
         for idx, cell in enumerate(block.cells):
             frame.cells[len(bc.cellvars) + idx] = cell

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -871,6 +871,15 @@ class TestBlocks(BaseRuPyPyTest):
             [1, 2, 3].map(&"to_s")
             """)
 
+    def test_too_few_block_arguments(self, space):
+        w_res = space.execute("""
+        def f
+            yield 1
+        end
+        return f { |a,b,c| [a,b,c] }
+        """)
+        assert self.unwrap(space, w_res) == [1, None, None]
+
     def test_block_return(self, space):
         w_res = space.execute("""
         def f


### PR DESCRIPTION
This should work, but throws an assertion error

``` ruby
def foo
  yield 1
end

foo {|a,b,c| puts a,b,c}
```
