### PR TITLE
Missing Exception#backtrace

### DIFF
--- a/rupypy/error.py
+++ b/rupypy/error.py
@@ -10,25 +10,12 @@ class RubyError(Exception):
 
 
 def format_traceback(space, exc):
-    last_instr_idx = 0
-    frame = exc.frame
-    yield "%s:%d:in `%s': %s (%s)\n" % (
-        frame.get_filename(),
-        frame.get_lineno(exc.last_instructions, last_instr_idx),
-        frame.get_code_name(),
-        exc.msg,
-        space.getclass(exc).name,
-    )
-    last_instr_idx += 1
-    frame = frame.backref()
-    while frame is not None and frame.has_contents():
-        yield "\tfrom %s:%d:in `%s'\n" % (
-            frame.get_filename(),
-            frame.get_lineno(exc.last_instructions, last_instr_idx),
-            frame.get_code_name(),
-        )
-        last_instr_idx += 1
-        frame = frame.backref()
+    w_ary = space.send(exc, space.newsymbol("backtrace"))
+    assert space.getclass(w_ary) is space.w_array
+    ary = space.listview(w_ary)
+    yield "%s: %s (%s)\n" % (space.str_w(ary[0]), exc.msg, space.getclass(exc).name)
+    for w_line in ary[1:]:
+        yield "\tfrom %s\n" % space.str_w(w_line)
 
 
 def print_traceback(space, w_exc):

--- a/rupypy/objects/exceptionobject.py
+++ b/rupypy/objects/exceptionobject.py
@@ -44,6 +44,22 @@ class W_ExceptionObject(W_Object):
     def method_message(self, space):
         return space.newstr_fromstr(self.msg)
 
+    @classdef.method("backtrace")
+    def method_backtrace(self, space):
+        last_instr_idx = 0
+        frame = self.frame
+        results = []
+        while frame is not None and frame.has_contents():
+            results.append(space.newstr_fromstr("%s:%d:in `%s'" % (
+                frame.get_filename(),
+                frame.get_lineno(self.last_instructions, last_instr_idx),
+                frame.get_code_name(),
+            )))
+            last_instr_idx += 1
+            frame = frame.backref()
+        return space.newarray(results)
+
+
 class W_ScriptError(W_ExceptionObject):
     classdef = ClassDef("ScriptError", W_ExceptionObject.classdef)
     method_allocate = new_exception_allocate(classdef)

--- a/tests/objects/test_exceptionobject.py
+++ b/tests/objects/test_exceptionobject.py
@@ -52,3 +52,21 @@ class TestExceptionObject(BaseRuPyPyTest):
         end
         """)
         assert self.unwrap(space, w_res) == "foo"
+
+    def test_backtrace(self, space):
+        w_res = space.execute("""
+        def f
+            yield
+        end
+        begin
+            f { 1 / 0}
+        rescue Exception => e
+            return e.backtrace
+        end
+        """)
+        assert self.unwrap(space, w_res) == [
+            "-e:6:in `/'",
+            "-e:6:in `block in <main>'",
+            "-e:3:in `f'",
+            "-e:6:in `<main>'"
+        ]


### PR DESCRIPTION
Anytime a spec fails we hit an

```
undefined method `backtrace' for NameError (NoMethodError)
```

or similar.
