### PR TITLE
Fixed symlink resolution in test

### DIFF
--- a/tests/lib/test_dir.py
+++ b/tests/lib/test_dir.py
@@ -41,11 +41,8 @@ class TestDir(BaseRuPyPyTest):
         dirs << Dir.pwd
         return dirs
         """ % tmpdir)
-
-        cwd = os.getcwd()
-        os.chdir(str(tmpdir))
-        tempdir = os.getcwd()
-        assert self.unwrap(space, w_res) == [cwd, tempdir, cwd]
+        paths = [os.getcwd(), os.path.realpath(str(tmpdir)), os.getcwd()]
+        assert self.unwrap(space, w_res) == paths
 
         monkeypatch.setenv("HOME", str(tmpdir))
         w_res = space.execute("""
@@ -53,6 +50,5 @@ class TestDir(BaseRuPyPyTest):
             return Dir.pwd
         end
         """)
-        os.chdir(str(tmpdir))
-        tempdir = os.getcwd()
-        assert space.str_w(w_res) == tempdir
+
+        assert space.str_w(w_res) == os.path.realpath(str(tmpdir))


### PR DESCRIPTION
Test failed comparing /var/… to /private/var/… (/var symlinks to /private/var in OS X).
Switching to this directory via os.chdir and reading out the cwd returns the correct path without symlinks.
