### PR TITLE
Unicode symbols throw parser error

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1478,6 +1478,8 @@ HERE
         assert space.parse(":-@") == sym("-@")
         assert space.parse(":+@") == sym("+@")
         assert space.parse(":$-w") == sym("$-w")
+        assert space.parse(u":åäö".encode("utf-8")) == sym(u"åäö".encode("utf-8"))
+        assert space.parse(u":８ ９ ＡＢＣ".encode("utf-8")) == sym(u"８ ９ ＡＢＣ".encode("utf-8"))
 
     def test_do_symbol(self, space):
         r = space.parse("f :do")

--- a/topaz/lexer.py
+++ b/topaz/lexer.py
@@ -362,7 +362,7 @@ class Lexer(object):
                 self.add(ch)
                 yield self.emit_identifier(command_state, "FID")
                 break
-            elif ch.isalnum() or ch == "_":
+            elif ch.isalnum() or ch == "_" or ord(ch) > 127:
                 self.add(ch)
             else:
                 self.unread()


### PR DESCRIPTION
This blocks some symbol specs from even parsing

``` ruby
:åäö
```

This works fine, though:

``` ruby
:"åäö"
```

I found the parser ends up in `literal_symbol`, with only the first character in the token.getstr().
