### PR TITLE
Update getting started doc to execute rpython with python

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -39,7 +39,7 @@ We recommend installing ``PyPy`` and ``RPly`` into a `virtualenv`_.
 Once everything is setup (make sure ``rpython`` is on your ``PYTHONPATH``), you
 can compile Topaz::
 
-    $ path/to/pypy/rpython/bin/rpython -Ojit targettopaz.py
+    $ python path/to/pypy/rpython/bin/rpython -Ojit targettopaz.py
 
 Wait a bit (you'll see fractals printing, and some progress indicators). On a
 recent machine it'll take about ten minutes. And then you'll have a ``topaz``


### PR DESCRIPTION
The default use of pypy failed if the user did not have a pypy
binary installed in their PATH. Almost everybody should have
a python in their path.
