### PR TITLE
Approximate float comparison in test_math.py

### DIFF
--- a/tests/modules/test_math.py
+++ b/tests/modules/test_math.py
@@ -4,6 +4,9 @@ from ..base import BaseTopazTest
 
 
 class TestMath(BaseTopazTest):
+    def compare_float_lists(self, result, expected):
+        assert all([abs(r - e) < 1e-15 for r, e in zip(result, expected)])
+
     def test_pi(self, space):
         w_res = space.execute("return Math::PI")
         assert space.float_w(w_res) == math.pi
@@ -22,5 +25,4 @@ class TestMath(BaseTopazTest):
 
     def test_log(self, space):
         w_res = space.execute("return [Math.log(4, 10), Math.log(28), Math.log(3, 4)]")
-        expected = [math.log(4, 10), math.log(28), math.log(3, 4)]
-        assert all([abs(r - e) < 1e-15 for r, e in zip(self.unwrap(space, w_res), expected)])
+        self.compare_float_lists(self.unwrap(space, w_res), [math.log(4, 10), math.log(28), math.log(3, 4)])


### PR DESCRIPTION
TestMath.test_log fails on my system due to a float comparison issue:

```
    def test_log(self, space):
        w_res = space.execute("return [Math.log(4, 10), Math.log(28), Math.log(3, 4)]")
>       assert self.unwrap(space, w_res) == [math.log(4, 10), math.log(28), math.log(3, 4)]
E       assert [0.6020599913...4812503605781] == [0.60205999132...4812503605781]
E         At index 0 diff: 0.6020599913279623 != 0.6020599913279624
```

This branch switches to an approximate equality check. I don't know that this is the right way to solve the problem, but I couldn't find or think of anything better.
