### PR TITLE
Exception when the limit arg of each_line is 0

### DIFF
--- a/tests/objects/test_fileobject.py
+++ b/tests/objects/test_fileobject.py
@@ -320,6 +320,11 @@ class TestFile(BaseTopazTest):
         """ % f)
         assert self.unwrap(space, w_res) == ["01\n0", "2\n0", "\n04\n"]
 
+        with self.raises(space, "ArgumentError", "invalid limit: 0 for each_line"):
+            w_res = space.execute("""
+            File.new('%s').each_line(0) { |l| }
+            """ % f)
+
     def test_join(self, space):
         w_res = space.execute("return File.join('/abc', 'bin')")
         assert space.str_w(w_res) == "/abc/bin"

--- a/topaz/objects/fileobject.py
+++ b/topaz/objects/fileobject.py
@@ -211,6 +211,10 @@ class W_IOObject(W_Object):
             return self
         end
 
+        if limit == 0
+            raise ArgumentError.new("invalid limit: 0 for each_line")
+        end
+
         rest = ""
         nxt = read(8192)
         need_read = false


### PR DESCRIPTION
Make `IO#each_line` raise an `ArgumentError` when the `limit` argument is set to 0.

See [ruby/io.c](https://github.com/ruby/ruby/blob/trunk/io.c#L3254).
