### PR TITLE
Implements Kernel#p

### DIFF
--- a/tests/modules/test_kernel.py
+++ b/tests/modules/test_kernel.py
@@ -17,6 +17,11 @@ class TestKernel(BaseTopazTest):
         out, err = capfd.readouterr()
         assert out == "13"
 
+    def test_p(self, space, capfd):
+        space.execute("p 1,2,3")
+        out, err = capfd.readouterr()
+        assert out == "1\n2\n3\n"
+
     def test_lambda(self, space):
         w_res = space.execute("""
         l = lambda { |x| 3 }

--- a/topaz/modules/kernel.py
+++ b/topaz/modules/kernel.py
@@ -51,6 +51,10 @@ class Kernel(Module):
     def print *args
         $stdout.print(*args)
     end
+
+    def p *args
+        args.each { |arg| $stdout.print(arg.inspect + "\n") }
+    end
     """)
 
     @staticmethod


### PR DESCRIPTION
Implements `Kernel#p` (www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-p)
