### PR TITLE
Implement #reduce and #inject properly

### DIFF
--- a/lib-topaz/enumerable.rb
+++ b/lib-topaz/enumerable.rb
@@ -1,4 +1,6 @@
 module Enumerable
+  Undefined = Object.new
+
   def map
     result = []
     self.each do |x|
@@ -9,11 +11,37 @@ module Enumerable
 
   alias collect map
 
-  def inject memo
-    self.each do |x|
-      memo = (yield memo, x)
+  def inject(initial=Undefined, sym=Undefined, &block)
+    if !block || !sym.equal?(Undefined)
+      if sym.equal?(Undefined)
+        sym = initial
+        initial = Undefined
+      end
+
+      # Do the sym version
+
+      sym = sym.to_sym
+
+      each do |o|
+        if initial.equal?(Undefined)
+          initial = o
+        else
+          initial = initial.__send__(sym, o)
+        end
+      end
+
+      # Block version
+    else
+      each do |o|
+        if initial.equal?(Undefined)
+          initial = o
+        else
+          initial = block.call(initial, o)
+        end
+      end
     end
-    memo
+
+    initial.equal?(Undefined) ? nil : initial
   end
 
   alias reduce inject

--- a/spec/tags/core/enumerable/inject_tags.txt
+++ b/spec/tags/core/enumerable/inject_tags.txt
@@ -1,7 +1,1 @@
-fails:Enumerable#inject can take two argument
-fails:Enumerable#inject ignores the block if two arguments
-fails:Enumerable#inject can take a symbol argument
-fails:Enumerable#inject without argument takes a block with an accumulator (with first element as initial value) and the current element. Value of block becomes new accumulator
 fails:Enumerable#inject gathers whole arrays as elements when each yields multiple
-fails:Enumerable#inject without inject arguments(legacy rubycon)
-fails:Enumerable#inject returns nil when fails(legacy rubycon)

--- a/spec/tags/core/enumerable/reduce_tags.txt
+++ b/spec/tags/core/enumerable/reduce_tags.txt
@@ -1,10 +1,1 @@
-fails:Enumerable#reduce with argument takes a block with an accumulator (with argument as initial value) and the current element. Value of block becomes new accumulator
-fails:Enumerable#reduce produces an array of the accumulator and the argument when given a block with a *arg
-fails:Enumerable#reduce can take two argument
-fails:Enumerable#reduce ignores the block if two arguments
-fails:Enumerable#reduce can take a symbol argument
-fails:Enumerable#reduce without argument takes a block with an accumulator (with first element as initial value) and the current element. Value of block becomes new accumulator
 fails:Enumerable#reduce gathers whole arrays as elements when each yields multiple
-fails:Enumerable#reduce with inject arguments(legacy rubycon)
-fails:Enumerable#reduce without inject arguments(legacy rubycon)
-fails:Enumerable#reduce returns nil when fails(legacy rubycon)


### PR DESCRIPTION
Inspired by Rubinius' version.

One test is failing due to how Topaz unpacks block arguments.
