### PR TITLE
Remove Process.fork tests, untag core/process/fork_spec

### DIFF
--- a/tests/modules/test_process.py
+++ b/tests/modules/test_process.py
@@ -34,6 +34,25 @@ class TestProcess(BaseTopazTest):
         """)
         assert self.unwrap(space, w_res) == [False, 1]
 
+    def test_fork(self, space, monkeypatch, capfd):
+        monkeypatch.setattr(os, "fork", lambda: 0)
+        with self.raises(space, "SystemExit"):
+            space.execute("""
+            Process.fork do
+                puts "child"
+            end
+            """)
+        out, err = capfd.readouterr()
+        assert err == ""
+        assert out == "child\n"
+        monkeypatch.setattr(os, "fork", lambda: 200)
+        w_res = space.execute("""
+        return Process.fork do
+            puts "child"
+        end
+        """)
+        assert space.int_w(w_res) == 200
+
     @pytest.mark.parametrize("code", [0, 1, 173])
     def test_waitpid(self, space, code):
         pid = os.fork()


### PR DESCRIPTION
RubySpec's `Process.fork` examples pass. Since they do, existing tests can be removed as redundant.
