### PR TITLE
Making IO#readline behave better-er

### DIFF
--- a/lib-topaz/io.rb
+++ b/lib-topaz/io.rb
@@ -57,13 +57,17 @@ class IO
   end
 
   def readline(sep = $/, limit = nil)
+    if sep.is_a?(Fixnum) && limit.nil?
+      limit = sep
+      sep = $/
+    end
     raise IOError.new("closed stream") if closed?
     line = ""
     loop do
       c = getc
       break if c.nil? || c.empty?
       line << c
-      break if c == sep
+      break if c == sep || line.length == limit
     end
     raise EOFError.new("end of file reached") if line.empty?
     $_ = line

--- a/tests/objects/test_fileobject.py
+++ b/tests/objects/test_fileobject.py
@@ -401,6 +401,22 @@ class TestFile(BaseTopazTest):
         """ % (tmpdir.dirname, os.sep))
         assert space.str_w(w_res) == "first\nsecond\n"
 
+    def test_readline(self, space, tmpdir):
+        contents = "01\n02\n03\n04\n"
+        f = tmpdir.join("file.txt")
+        f.write(contents)
+        w_res = space.execute("return File.new('%s').readline" % f)
+        assert self.unwrap(space, w_res) == "01\n"
+
+        w_res = space.execute("return File.new('%s').readline('3')" % f)
+        assert self.unwrap(space, w_res) == "01\n02\n03"
+
+        w_res = space.execute("return File.new('%s').readline(1)" % f)
+        assert self.unwrap(space, w_res) == "0"
+
+        w_res = space.execute("return File.new('%s').readline('3', 4)" % f)
+        assert self.unwrap(space, w_res) == "01\n0"
+
     def test_readlines(self, space, tmpdir):
         contents = "01\n02\n03\n04\n"
         f = tmpdir.join("file.txt")


### PR DESCRIPTION
not including introduction of Yet Another Bad IO Buffering Implementation.
