### PR TITLE
Moving most of IO#readline down a layer to IO#gets

### DIFF
--- a/lib-topaz/io.rb
+++ b/lib-topaz/io.rb
@@ -57,6 +57,15 @@ class IO
   end
 
   def readline(sep = $/, limit = nil)
+    line = gets(sep, limit)
+    raise EOFError.new("end of file reached") if line.nil?
+    line
+  end
+
+  def gets(sep = $/, limit = nil)
+    if sep.nil?
+      return read
+    end
     if sep.is_a?(Fixnum) && limit.nil?
       limit = sep
       sep = $/
@@ -69,9 +78,8 @@ class IO
       line << c
       break if c == sep || line.length == limit
     end
-    raise EOFError.new("end of file reached") if line.empty?
     $_ = line
-    return line
+    line.empty? ? nil : line
   end
 
   def readlines(sep = $/, limit = nil)

--- a/spec/tags/core/io/gets_tags.txt
+++ b/spec/tags/core/io/gets_tags.txt
@@ -1,12 +1,7 @@
 fails:IO#gets with ASCII separator returns the separator's character representation
-fails:IO#gets assigns the returned line to $_
-fails:IO#gets returns nil if called at the end of the stream
-fails:IO#gets raises IOError on closed stream
-fails:IO#gets with no separator returns the next line of string that is separated by $/
 fails:IO#gets with no separator returns tainted strings
 fails:IO#gets with no separator updates lineno with each invocation
 fails:IO#gets with no separator updates $. with each invocation
-fails:IO#gets with nil separator returns the entire contents
 fails:IO#gets with nil separator returns tainted strings
 fails:IO#gets with nil separator updates lineno with each invocation
 fails:IO#gets with nil separator updates $. with each invocation


### PR DESCRIPTION
and starting to untag IO#gets specs as a result.
