### PR TITLE
Raise ArgumentError if args are passed to Array.allocate (untag spec)

### DIFF
--- a/spec/tags/core/array/allocate_tags.txt
+++ b/spec/tags/core/array/allocate_tags.txt
@@ -1,1 +1,0 @@
-fails:Array.allocate does not accept any arguments

--- a/topaz/objects/arrayobject.py
+++ b/topaz/objects/arrayobject.py
@@ -47,6 +47,10 @@ class W_ArrayObject(W_Object):
 
     @classdef.singleton_method("allocate")
     def singleton_method_allocate(self, space, args_w):
+        if len(args_w):
+            raise space.error(space.w_ArgumentError,
+                "wrong number of arguments(%d for 0)" % len(args_w)
+            )
         return W_ArrayObject(space, [], self)
 
     @classdef.method("initialize_copy", other_w="array")


### PR DESCRIPTION
Just found a failing spec and implemented it (Array.allocate should fail if any args are passed in.)
