### PR TITLE
 Test `Const::attr = nil` assignments, which are currently not supported

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -348,6 +348,11 @@ class TestParser(BaseTopazTest):
             ))
         ]))
 
+    def test_colon_attr_assignment(self, space):
+        assert space.parse("a::b = nil") == ast.Main(ast.Block([
+            ast.Statement(ast.Send(ast.Send(ast.Self(1), "a", [], None, 1), "b", [ast.Nil()], None, 1))
+        ]))
+
     def test_splat_rhs_assignment(self, space):
         assert space.parse("a,b,c = *[1,2,3]") == ast.Main(ast.Block([
             ast.Statement(ast.MultiAssignment(


### PR DESCRIPTION
This adds a unit test that currently raises a NotImplementedError
