### PR TITLE
Kernel#=== should check identity

### DIFF
--- a/spec/tags/core/kernel/case_compare_tags.txt
+++ b/spec/tags/core/kernel/case_compare_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel#=== for a class with #== and #equal? overridden to always be false returns true if the object id is the same even if both #== and #equal? return false

--- a/topaz/objects/objectobject.py
+++ b/topaz/objects/objectobject.py
@@ -147,6 +147,8 @@ class W_RootObject(W_BaseObject):
 
     @classdef.method("===")
     def method_eqeqeq(self, space, w_other):
+        if self is w_other:
+            return space.w_true
         return space.send(self, space.newsymbol("=="), [w_other])
 
     @classdef.method("send")


### PR DESCRIPTION
Kernel#=== for a class with #== and #equal? overridden to always be false returns true if the object id is the same even if both #== and #equal? return false
