### PR TITLE
Proc#=== is alias for Proc#call

### DIFF
--- a/spec/tags/core/proc/call_tags.txt
+++ b/spec/tags/core/proc/call_tags.txt
@@ -1,2 +1,0 @@
-fails:Proc#call on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on missing arguments when self is a lambda
-fails:Proc#call on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on excess arguments when self is a lambda

--- a/spec/tags/core/proc/case_compare_tags.txt
+++ b/spec/tags/core/proc/case_compare_tags.txt
@@ -1,1 +1,0 @@
-fails:Proc#=== on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on missing arguments when self is a lambda

--- a/spec/tags/core/proc/element_reference_tags.txt
+++ b/spec/tags/core/proc/element_reference_tags.txt
@@ -1,2 +1,0 @@
-fails:Proc#call on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on missing arguments when self is a lambda
-fails:Proc#call on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on excess arguments when self is a lambda

--- a/topaz/objects/procobject.py
+++ b/topaz/objects/procobject.py
@@ -27,6 +27,16 @@ class W_ProcObject(W_Object):
     def method_call(self, space, args_w, block):
         from topaz.interpreter import RaiseReturn, RaiseBreak
 
+        if (self.is_lambda and
+            (len(args_w) < (len(self.block.bytecode.arg_pos) - len(self.block.bytecode.defaults)) or
+            (self.block.bytecode.splat_arg_pos == -1 and len(args_w) > len(self.block.bytecode.arg_pos)))):
+            raise space.error(space.w_ArgumentError,
+                "wrong number of arguments (%d for %d)" % (
+                    len(args_w),
+                    len(self.block.bytecode.arg_pos) - len(self.block.bytecode.defaults)
+                )
+            )
+
         try:
             return space.invoke_block(self.block, args_w, block_arg=block)
         except RaiseReturn as e:


### PR DESCRIPTION
Fixes following specs:

Proc#===
- invokes self
- sets self's parameters to the given values
- can receive block arguments

Proc#=== on a Proc created with Proc.new
- replaces missing arguments with nil
- silently ignores extra arguments
- auto-explodes a single Array argument

Proc#=== on a Proc created with Kernel#lambda or Kernel#proc
- ignores excess arguments when self is a proc
- substitutes nil for missing arguments when self is a proc
- treats a single Array argument as a single argument when self is a lambda
- treats a single Array argument as a single argument when self is a proc
