### PR TITLE
Math type errors

### DIFF
--- a/spec/tags/core/math/acos_tags.txt
+++ b/spec/tags/core/math/acos_tags.txt
@@ -1,3 +1,2 @@
 fails:Math.acos raises an Errno::EDOM if the argument is greater than 1.0
 fails:Math.acos raises an Errno::EDOM if the argument is less than -1.0
-fails:Math.acos raises a TypeError if the string argument cannot be coerced with Float()

--- a/spec/tags/core/math/acosh_tags.txt
+++ b/spec/tags/core/math/acosh_tags.txt
@@ -1,2 +1,1 @@
 fails:Math.acosh it raises Errno::EDOM if the passed argument is less than -1.0 or greater than 1.0
-fails:Math.acosh raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/asin_tags.txt
+++ b/spec/tags/core/math/asin_tags.txt
@@ -1,3 +1,2 @@
 fails:Math.asin raises an Errno::EDOM if the argument is greater than 1.0
 fails:Math.asin raises an Errno::EDOM if the argument is less than -1.0
-fails:Math.asin raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/asinh_tags.txt
+++ b/spec/tags/core/math/asinh_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.asinh raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/atan2_tags.txt
+++ b/spec/tags/core/math/atan2_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.atan2 raises an TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/atan_tags.txt
+++ b/spec/tags/core/math/atan_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.atan raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/cos_tags.txt
+++ b/spec/tags/core/math/cos_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.cos raises a TypeError unless the argument is Numeric and has #to_f

--- a/spec/tags/core/math/cosh_tags.txt
+++ b/spec/tags/core/math/cosh_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.cosh raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/erf_tags.txt
+++ b/spec/tags/core/math/erf_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.erf raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/erfc_tags.txt
+++ b/spec/tags/core/math/erfc_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.erfc raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/exp_tags.txt
+++ b/spec/tags/core/math/exp_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.exp raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/frexp_tags.txt
+++ b/spec/tags/core/math/frexp_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.frexp raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/hypot_tags.txt
+++ b/spec/tags/core/math/hypot_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.hypot raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/ldexp_tags.txt
+++ b/spec/tags/core/math/ldexp_tags.txt
@@ -1,2 +1,1 @@
-fails:Math.ldexp raises a TypeError if the first argument cannot be coerced with Float()
 fails:Math.ldexp raises RangeError if NaN is given as the second arg

--- a/spec/tags/core/math/log10_tags.txt
+++ b/spec/tags/core/math/log10_tags.txt
@@ -1,2 +1,1 @@
 fails:Math.log10 raises an Errno::EDOM if the argument is less than 0
-fails:Math.log10 raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/log2_tags.txt
+++ b/spec/tags/core/math/log2_tags.txt
@@ -1,2 +1,0 @@
-fails:Math.log2 raises an TypeError if the argument cannot be coerced with Float()
-fails:Math.log2 raises an TypeError if passed a numerical argument as a string

--- a/spec/tags/core/math/log_tags.txt
+++ b/spec/tags/core/math/log_tags.txt
@@ -1,4 +1,1 @@
 fails:Math.log raises an Errno::EDOM if the argument is less than 0
-fails:Math.log raises a TypeError if the argument cannot be coerced with Float()
-fails:Math.log raises a TypeError for numerical values passed as string
-fails:Math.log raises a TypeError when the numerical base cannot be coerced to a float

--- a/spec/tags/core/math/sin_tags.txt
+++ b/spec/tags/core/math/sin_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.sin raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/sinh_tags.txt
+++ b/spec/tags/core/math/sinh_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.sinh raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/sqrt_tags.txt
+++ b/spec/tags/core/math/sqrt_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.sqrt raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/tan_tags.txt
+++ b/spec/tags/core/math/tan_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.tan raises a TypeError if the argument cannot be coerced with Float()

--- a/spec/tags/core/math/tanh_tags.txt
+++ b/spec/tags/core/math/tanh_tags.txt
@@ -1,1 +1,0 @@
-fails:Math.tanh raises an TypeError if the argument cannot be coerced with Float()

--- a/tests/modules/test_math.py
+++ b/tests/modules/test_math.py
@@ -133,6 +133,11 @@ class TestMath(BaseTopazTest):
         w_res = space.execute("return Math.ldexp(Math.frexp(1234)[0], 11)")
         assert self.unwrap(space, w_res) == 1234
 
+        with self.raises(space, "TypeError",
+                         "can't convert String into Integer"):
+            space.execute("Math.ldexp('1', 2)")
+            space.execute("Math.ldexp(1, '2')")
+
     def test_log(self, space):
         with self.raises(space, "Math::DomainError", 'Numerical argument is out of domain - "log"'):
             space.execute("Math.log(-1)")
@@ -211,3 +216,17 @@ class TestMath(BaseTopazTest):
     def test_erfc(self, space):
         w_res = space.execute("return [Math.erfc(-1), Math.erfc(0), Math.erfc(1.5)]")
         assert self.unwrap(space, w_res) == [math.erfc(-1), 1.0, math.erfc(1.5)]
+
+    def test_type_error(self, space):
+        for methodname in ['sin', 'cos', 'tan', 'asin', 'acos', 'atan',
+                           'sinh', 'cosh', 'tanh', 'asinh', 'acosh', 'atanh',
+                           'sqrt', 'cbrt', 'erf', 'erfc', 'gamma', 'lgamma',
+                           'exp', 'frexp', 'log', 'log10', 'log2']:
+            with self.raises(space, "TypeError",
+                             "can't convert String into Float"):
+                space.execute("Math.%s('1.0')" %methodname)
+        for methodname in ['hypot', 'atan2']:
+            with self.raises(space, "TypeError",
+                             "can't convert String into Float"):
+                space.execute("Math.%s('1', 2)" %methodname)
+                space.execute("Math.%s(1, '2')" %methodname)

--- a/tests/modules/test_math.py
+++ b/tests/modules/test_math.py
@@ -134,8 +134,10 @@ class TestMath(BaseTopazTest):
         assert self.unwrap(space, w_res) == 1234
 
         with self.raises(space, "TypeError",
-                         "can't convert String into Integer"):
+                         "can't convert String into Float"):
             space.execute("Math.ldexp('1', 2)")
+        with self.raises(space, "TypeError",
+                         "can't convert String into Integer"):
             space.execute("Math.ldexp(1, '2')")
 
     def test_log(self, space):

--- a/topaz/coerce.py
+++ b/topaz/coerce.py
@@ -38,6 +38,14 @@ class Coerce(object):
             return space.float_w(space.send(w_obj, space.newsymbol("Float"), [w_obj]))
 
     @staticmethod
+    def strictfloat(space, w_obj):
+        if not space.is_kind_of(w_obj, space.w_numeric):
+            clsname = w_obj.getclass(space).name
+            raise space.error(space.w_TypeError,
+                              "can't convert %s into Float" %clsname)
+        return Coerce.float(space, w_obj)
+
+    @staticmethod
     def str(space, w_obj):
         if space.is_kind_of(w_obj, space.w_string) or space.is_kind_of(w_obj, space.w_symbol):
             return space.str_w(w_obj)

--- a/topaz/modules/math.py
+++ b/topaz/modules/math.py
@@ -17,11 +17,11 @@ class Math(Module):
         space.set_const(w_mod, "E", space.newfloat(math.e))
         space.set_const(w_mod, "DomainError", space.getclassfor(W_DomainError))
 
-    @moduledef.function("acos", value="float")
+    @moduledef.function("acos", value="strictfloat")
     def method_acos(self, space, value):
         return space.newfloat(math.acos(value))
 
-    @moduledef.function("acosh", value="float")
+    @moduledef.function("acosh", value="strictfloat")
     def method_acosh(self, space, value):
         try:
             res = math.acosh(value)
@@ -29,23 +29,23 @@ class Math(Module):
             raise space.error(space.getclassfor(W_DomainError), 'Numerical argument is out of domain - "acosh"')
         return space.newfloat(res)
 
-    @moduledef.function("asin", value="float")
+    @moduledef.function("asin", value="strictfloat")
     def method_asin(self, space, value):
         return space.newfloat(math.asin(value))
 
-    @moduledef.function("asinh", value="float")
+    @moduledef.function("asinh", value="strictfloat")
     def method_asinh(self, space, value):
         return space.newfloat(math.asinh(value))
 
-    @moduledef.function("atan", value="float")
+    @moduledef.function("atan", value="strictfloat")
     def method_atan(self, space, value):
         return space.newfloat(math.atan(value))
 
-    @moduledef.function("atan2", value1="float", value2="float")
+    @moduledef.function("atan2", value1="strictfloat", value2="strictfloat")
     def method_atan2(self, space, value1, value2):
         return space.newfloat(math.atan2(value1, value2))
 
-    @moduledef.function("atanh", value="float")
+    @moduledef.function("atanh", value="strictfloat")
     def method_atanh(self, space, value):
         try:
             res = math.atanh(value)
@@ -57,18 +57,18 @@ class Math(Module):
                 raise space.error(space.getclassfor(W_DomainError), 'Numerical argument is out of domain - "atanh"')
         return space.newfloat(res)
 
-    @moduledef.function("cbrt", value="float")
+    @moduledef.function("cbrt", value="strictfloat")
     def method_cbrt(self, space, value):
         if value < 0:
             return space.newfloat(-math.pow(-value, 1.0 / 3.0))
         else:
             return space.newfloat(math.pow(value, 1.0 / 3.0))
 
-    @moduledef.function("cos", value="float")
+    @moduledef.function("cos", value="strictfloat")
     def method_cos(self, space, value):
         return space.newfloat(math.cos(value))
 
-    @moduledef.function("cosh", value="float")
+    @moduledef.function("cosh", value="strictfloat")
     def method_cosh(self, space, value):
         try:
             res = math.cosh(value)
@@ -76,18 +76,18 @@ class Math(Module):
             res = rfloat.copysign(rfloat.INFINITY, value)
         return space.newfloat(res)
 
-    @moduledef.function("exp", value="float")
+    @moduledef.function("exp", value="strictfloat")
     def method_exp(self, space, value):
         return space.newfloat(math.exp(value))
 
-    @moduledef.function("frexp", value="float")
+    @moduledef.function("frexp", value="strictfloat")
     def method_frexp(self, space, value):
         mant, exp = math.frexp(value)
         w_mant = space.newfloat(mant)
         w_exp = space.newint(exp)
         return space.newarray([w_mant, w_exp])
 
-    @moduledef.function("gamma", value="float")
+    @moduledef.function("gamma", value="strictfloat")
     def method_gamma(self, space, value):
         try:
             res = rfloat.gamma(value)
@@ -101,7 +101,7 @@ class Math(Module):
             res = rfloat.INFINITY
         return space.newfloat(res)
 
-    @moduledef.function("lgamma", value="float")
+    @moduledef.function("lgamma", value="strictfloat")
     def method_lgamma(self, space, value):
         try:
             res = rfloat.lgamma(value)
@@ -113,15 +113,15 @@ class Math(Module):
         sign = 1 if gamma > 0 else -1 if gamma < 0 else 0
         return space.newarray([space.newfloat(res), space.newint(sign)])
 
-    @moduledef.function("hypot", value1="float", value2="float")
+    @moduledef.function("hypot", value1="strictfloat", value2="strictfloat")
     def method_hypot(self, space, value1, value2):
         return space.newfloat(math.hypot(value1, value2))
 
-    @moduledef.function("ldexp", value1="float", value2="int")
+    @moduledef.function("ldexp", value1="strictfloat", value2="int")
     def method_ldexp(self, space, value1, value2):
         return space.newfloat(math.ldexp(value1, value2))
 
-    @moduledef.function("log", value="float", base="float")
+    @moduledef.function("log", value="strictfloat", base="strictfloat")
     def method_log(self, space, value, base=math.e):
         try:
             res = 0.0
@@ -137,7 +137,7 @@ class Math(Module):
 
         return space.newfloat(res)
 
-    @moduledef.function("log10", value="float")
+    @moduledef.function("log10", value="strictfloat")
     def method_log10(self, space, value):
         try:
             res = math.log10(value)
@@ -149,7 +149,7 @@ class Math(Module):
 
         return space.newfloat(res)
 
-    @moduledef.function("log2", value="float")
+    @moduledef.function("log2", value="strictfloat")
     def method_log2(self, space, value):
         try:
             res = math.log(value) / math.log(2)
@@ -161,11 +161,11 @@ class Math(Module):
 
         return space.newfloat(res)
 
-    @moduledef.function("sin", value="float")
+    @moduledef.function("sin", value="strictfloat")
     def method_sin(self, space, value):
         return space.newfloat(math.sin(value))
 
-    @moduledef.function("sinh", value="float")
+    @moduledef.function("sinh", value="strictfloat")
     def method_sinh(self, space, value):
         try:
             res = math.sinh(value)
@@ -173,11 +173,11 @@ class Math(Module):
             res = rfloat.copysign(rfloat.INFINITY, value)
         return space.newfloat(res)
 
-    @moduledef.function("sqrt", value="float")
+    @moduledef.function("sqrt", value="strictfloat")
     def method_sqrt(self, space, value):
         return space.newfloat(math.sqrt(value))
 
-    @moduledef.function("tan", value="float")
+    @moduledef.function("tan", value="strictfloat")
     def method_tan(self, space, value):
         try:
             res = math.tan(value)
@@ -185,15 +185,15 @@ class Math(Module):
             res = rfloat.NAN
         return space.newfloat(res)
 
-    @moduledef.function("tanh", value="float")
+    @moduledef.function("tanh", value="strictfloat")
     def method_tanh(self, space, value):
         return space.newfloat(math.tanh(value))
 
-    @moduledef.function("erf", value="float")
+    @moduledef.function("erf", value="strictfloat")
     def method_erf(self, space, value):
         return space.newfloat(rfloat.erf(value))
 
-    @moduledef.function("erfc", value="float")
+    @moduledef.function("erfc", value="strictfloat")
     def method_erfc(self, space, value):
         return space.newfloat(rfloat.erfc(value))
 


### PR DESCRIPTION
Many files in spec/tags/core/math had a fail message that looked something like this:

fails:Math.<methodname> raises a TypeError if the argument cannot be coerced with Float()

This happened although the methods in the class for the Math module were decorated like so (at least the ones taking one argument):

@moduledef.function("<methodname>", value="float")

What happened was that Coerce.float delegated the conversion into a float to Float which raised an ArgumentError instead of the desired TypeError. Furthermore, a String like '1' or '2.0' was gladly accepted although ruby 1.9.3 also raises a TypeError in this case (this behaviour is not covered by rubyspec, so I wrote/modified some unittests in tests/modules/test_math.py).
In order to solve this problem I wrote a new method in Coerce, strictfloat. It will only delegate to Coerce.float if the input is an object representing a Ruby Numeric. Otherwise it will raise a TypeError. All methods in the Math module now only accept strictfloats rather than floats.
Thanks to this change a lot more specs in rubyspec/core/math now pass.
