### PR TITLE
fix hash#each yields array

### DIFF
--- a/lib-topaz/hash.rb
+++ b/lib-topaz/hash.rb
@@ -8,7 +8,7 @@ class Hash
       rescue StopIteration
         return self
       end
-      yield key, value
+      yield [key, value]
     end
   end
   alias each_pair each

--- a/spec/tags/core/hash/each_pair_tags.txt
+++ b/spec/tags/core/hash/each_pair_tags.txt
@@ -1,2 +1,2 @@
-fails:Hash#each_pair yields a [[key, value]] Array for each pair to a block expecting |*args|
 fails:Hash#each_pair properly expands (or not) child class's 'each'-yielded args
+fails:Hash#each_pair yields the key only to a block expecting |key,|

--- a/spec/tags/core/hash/each_tags.txt
+++ b/spec/tags/core/hash/each_tags.txt
@@ -1,2 +1,2 @@
-fails:Hash#each yields a [[key, value]] Array for each pair to a block expecting |*args|
 fails:Hash#each properly expands (or not) child class's 'each'-yielded args
+fails:Hash#each yields the key only to a block expecting |key,|


### PR DESCRIPTION
was

```
./bin/topaz -e '{1 => 2}.each{ |a| p a }'
1
```

now

```
./bin/topaz -e '{1 => 2}.each{ |a| p a }'
[1, 2]
```
