### PR TITLE
Untag specs for Kernel#binding

### DIFF
--- a/spec/tags/core/kernel/binding_tags.txt
+++ b/spec/tags/core/kernel/binding_tags.txt
@@ -1,3 +1,1 @@
 fails:Kernel#binding is a private method
-fails:Kernel#binding returns a Binding object
-fails:Kernel#binding uses the class as self in a Class.new block


### PR DESCRIPTION
Specs untagged:

Kernel#binding
- returns a Binding object
- uses the class as self in a Class.new block
