### PR TITLE
Module#name

### DIFF
--- a/spec/tags/core/module/name_tags.txt
+++ b/spec/tags/core/module/name_tags.txt
@@ -1,6 +1,3 @@
-fails:Module#name is nil for a nested module created with the module keyword
 fails:Module#name is set with a conditional assignment to a nested constant
 fails:Module#name is set with a conditional assignment to a constant
 fails:Module#name preserves the encoding in which the class was defined
-fails:Module#name is set when the anonymous outer module name is set
-fails:Module#name is nil when assigned to a constant in an anonymous module

--- a/topaz/interpreter.py
+++ b/topaz/interpreter.py
@@ -202,8 +202,9 @@ class Interpreter(object):
         w_value = frame.pop()
         w_scope = frame.pop()
         space.set_const(w_scope, name, w_value)
-        if isinstance(w_value, W_ModuleObject) and w_value.name is None:
-            w_value.name = space.buildname(name, w_scope)
+        if (isinstance(w_value, W_ModuleObject) and w_value.name is None
+            and isinstance(w_scope, W_ModuleObject) and w_scope.name is not None):
+            w_value.set_name_in_scope(space, name, w_scope)
         frame.push(w_value)
 
     def DEFINED_CONSTANT(self, space, bytecode, frame, pc, idx):

--- a/topaz/objects/moduleobject.py
+++ b/topaz/objects/moduleobject.py
@@ -315,6 +315,12 @@ class W_ModuleObject(W_RootObject):
     def method_removed(self, space, w_name):
         space.send(self, space.newsymbol("method_removed"), [w_name])
 
+    def set_name_in_scope(self, space, name, w_scope):
+        self.name = space.buildname(name, w_scope)
+        for name, w_const in self.constants_w.iteritems():
+            if isinstance(w_const, W_ModuleObject):
+                w_const.set_name_in_scope(space, name, self)
+
     @classdef.singleton_method("nesting")
     def singleton_method_nesting(self, space):
         frame = space.getexecutioncontext().gettoprubyframe()

--- a/topaz/objspace.py
+++ b/topaz/objspace.py
@@ -441,7 +441,7 @@ class ObjectSpace(object):
         if w_scope is not None:
             assert isinstance(w_scope, W_ModuleObject)
             if w_scope is not self.w_object:
-                complete_name = "%s::%s" % (w_scope.name, name)
+                complete_name = "%s::%s" % (self.obj_to_s(w_scope), name)
         return complete_name
 
     def int_w(self, w_obj):


### PR DESCRIPTION
Specs fixed:

Module#name
- is nil for a nested module created with the module keyword
- is set when the anonymous outer module name is set
- is nil when assigned to a constant in an anonymous module
