### PR TITLE
Exception#==

### DIFF
--- a/spec/tags/core/exception/equal_value_tags.txt
+++ b/spec/tags/core/exception/equal_value_tags.txt
@@ -1,8 +1,0 @@
-fails:Exception#== returns true if one exception is the dup'd copy of the other
-fails:Exception#== returns true if both exceptions have the same class, no message, and no backtrace
-fails:Exception#== returns true if both exceptions have the same class, the same message, and no backtrace
-fails:Exception#== returns true if both exceptions have the same class, the same message, and the same backtrace
-fails:Exception#== returns true if the two exceptions inherit from Exception but have different classes
-fails:Exception#== returns true if the two objects subclass Exception and have the same message and backtrace
-fails:Exception#== returns false if the two exceptions differ only in their backtrace
-fails:Exception#== returns false if the two exceptions differ only in their message


### PR DESCRIPTION
Specs fixed:

Exception#==
- returns true if one exception is the dup'd copy of the other
- returns true if both exceptions have the same class, no message, and no backtrace
- returns true if both exceptions have the same class, the same message, and no backtrace
- returns true if both exceptions have the same class, the same message, and the same backtrace
- returns true if the two exceptions inherit from Exception but have different classes
- returns true if the two objects subclass Exception and have the same message and backtrace
- returns false if the two exceptions differ only in their backtrace
- returns false if the two exceptions differ only in their message
