### PR TITLE
BasicObject#instance_exec

### DIFF
--- a/spec/tags/core/basicobject/instance_exec_tags.txt
+++ b/spec/tags/core/basicobject/instance_exec_tags.txt
@@ -1,3 +1,1 @@
 fails:BasicObject#instance_exec is a public instance method
-fails:BasicObject#instance_exec sets self to the receiver in the context of the passed block
-fails:BasicObject#instance_exec passes arguments to the block

--- a/topaz/objects/objectobject.py
+++ b/topaz/objects/objectobject.py
@@ -98,6 +98,19 @@ class W_BaseObject(W_Root):
         else:
             return space.invoke_block(block.copy(space, w_self=self), [])
 
+    @classdef.method("instance_exec")
+    def method_instance_exec(self, space, args_w, block):
+        if block is None:
+            raise space.error(space.w_LocalJumpError, "no block given")
+        return space.invoke_block(
+            block.copy(
+                space,
+                w_self=self,
+                lexical_scope=StaticScope(self, None)
+            ),
+            args_w
+        )
+
     @classdef.method("singleton_method_removed")
     def method_singleton_method_removed(self, space, w_name):
         return space.w_nil


### PR DESCRIPTION
Specs fixed:

BasicObject#instance_exec
- sets self to the receiver in the context of the passed block
- passes arguments to the block
