### PR TITLE
Module#extend_object

### DIFF
--- a/spec/tags/core/module/extend_object_tags.txt
+++ b/spec/tags/core/module/extend_object_tags.txt
@@ -1,3 +1,0 @@
-fails:Module#extend_object is called when #extend is called on an object
-fails:Module#extend_object extends the given object with its constants and methods by default
-fails:Module#extend_object is called even when private

--- a/topaz/objects/moduleobject.py
+++ b/topaz/objects/moduleobject.py
@@ -282,15 +282,10 @@ class W_ModuleObject(W_RootObject):
         if space.respond_to(self, "included"):
             space.send(self, "included", [w_mod])
 
-    def extend_object(self, space, w_obj, w_mod):
-        if w_mod not in self.ancestors():
-            self.included_modules = [w_mod] + self.included_modules
-            w_mod.extended(space, w_obj, self)
-
-    def extended(self, space, w_obj, w_mod):
-        self.descendants.append(w_mod)
-        if space.respond_to(self, "extended"):
-            space.send(self, "extended", [w_obj])
+    def extend_object(self, space, w_mod):
+        if self not in w_mod.ancestors():
+            self.descendants.append(w_mod)
+            w_mod.included_modules = [self] + w_mod.included_modules
 
     def set_visibility(self, space, names_w, visibility):
         names = [space.symbol_w(w_name) for w_name in names_w]
@@ -456,6 +451,10 @@ class W_ModuleObject(W_RootObject):
     def method_extended(self, space, w_mod):
         # TODO: should be private
         pass
+
+    @classdef.method("extend_object")
+    def method_extend_object(self, space, w_obj):
+        self.extend_object(space, space.getsingletonclass(w_obj))
 
     @classdef.method("name")
     def method_name(self, space):

--- a/topaz/objects/objectobject.py
+++ b/topaz/objects/objectobject.py
@@ -152,7 +152,8 @@ class W_RootObject(W_BaseObject):
                 space.w_TypeError,
                 "wrong argument type %s (expected Module)" % name
             )
-        self.getsingletonclass(space).extend_object(space, self, w_mod)
+        space.send(w_mod, "extend_object", [self])
+        space.send(w_mod, "extended", [self])
 
     @classdef.method("inspect")
     def method_inspect(self, space):


### PR DESCRIPTION
Specs fixed:

Module#extend_object
- is called when #extend is called on an object
- extends the given object with its constants and methods by default
- is called even when private
