### PR TITLE
Module#remove_const

### DIFF
--- a/spec/tags/core/module/remove_const_tags.txt
+++ b/spec/tags/core/module/remove_const_tags.txt
@@ -1,6 +1,1 @@
-fails:Module#remove_const removes the constant specified by a String or Symbol from the receiver's constant table
-fails:Module#remove_const returns the value of the removed constant
-fails:Module#remove_const raises a NameError if the name contains non-alphabetic characters except '_'
-fails:Module#remove_const calls #to_str to convert the given name to a String
-fails:Module#remove_const raises a TypeError if conversion to a String by calling #to_str fails
 fails:Module#remove_const is a private method

--- a/topaz/objects/moduleobject.py
+++ b/topaz/objects/moduleobject.py
@@ -531,6 +531,19 @@ class W_ModuleObject(W_RootObject):
         space.set_const(self, const, w_value)
         return w_value
 
+    @classdef.method("remove_const", name="str")
+    def method_remove_const(self, space, name):
+        space._check_const_name(name)
+        w_res = self.find_local_const(space, name)
+        if w_res is None:
+            self_name = space.obj_to_s(self)
+            raise space.error(space.w_NameError,
+                "uninitialized constant %s::%s" % (self_name, name)
+            )
+        del self.constants_w[name]
+        self.mutated()
+        return w_res
+
     @classdef.method("class_variable_defined?", name="symbol")
     def method_class_variable_definedp(self, space, name):
         return space.newbool(self.find_class_var(space, name) is not None)


### PR DESCRIPTION
Specs fixed:

Module#remove_const
- removes the constant specified by a String or Symbol from the receiver's constant table
- returns the value of the removed constant
- raises a NameError if the name contains non-alphabetic characters except '_'
- calls #to_str to convert the given name to a String
- raises a TypeError if conversion to a String by calling #to_str fails
