### PR TITLE
Move methods from Object to Kernel

### DIFF
--- a/spec/tags/core/basicobject/basicobject_tags.txt
+++ b/spec/tags/core/basicobject/basicobject_tags.txt
@@ -1,4 +1,3 @@
 fails:BasicObject raises NameError when referencing built-in constants
 fails:BasicObject does not define built-in constants (according to defined?)
 fails:BasicObject includes itself in its list of constants
-fails:BasicObject subclass contains Kernel methods when including Kernel

--- a/topaz/objects/objectobject.py
+++ b/topaz/objects/objectobject.py
@@ -1,10 +1,10 @@
 import copy
 
 from rpython.rlib import jit
-from rpython.rlib.objectmodel import compute_unique_id, compute_identity_hash
+from rpython.rlib.objectmodel import compute_unique_id
 
 from topaz.mapdict import MapTransitionCache
-from topaz.module import ClassDef, check_frozen
+from topaz.module import ClassDef
 from topaz.scope import StaticScope
 
 
@@ -132,80 +132,6 @@ class W_RootObject(W_BaseObject):
     @classdef.setup_class
     def setup_class(cls, space, w_cls):
         space.w_top_self = W_Object(space, w_cls)
-
-    @classdef.method("object_id")
-    def method_object_id(self, space):
-        return space.send(self, "__id__")
-
-    @classdef.method("singleton_class")
-    def method_singleton_class(self, space):
-        return space.getsingletonclass(self)
-
-    @classdef.method("extend")
-    def method_extend(self, space, w_mod):
-        if not space.is_kind_of(w_mod, space.w_module) or space.is_kind_of(w_mod, space.w_class):
-            if space.is_kind_of(w_mod, space.w_class):
-                name = "Class"
-            else:
-                name = space.obj_to_s(space.getclass(w_mod))
-            raise space.error(
-                space.w_TypeError,
-                "wrong argument type %s (expected Module)" % name
-            )
-        space.send(w_mod, "extend_object", [self])
-        space.send(w_mod, "extended", [self])
-
-    @classdef.method("inspect")
-    def method_inspect(self, space):
-        return space.send(self, "to_s")
-
-    @classdef.method("to_s")
-    def method_to_s(self, space):
-        return space.newstr_fromstr(space.any_to_s(self))
-
-    @classdef.method("===")
-    def method_eqeqeq(self, space, w_other):
-        if self is w_other:
-            return space.w_true
-        return space.send(self, "==", [w_other])
-
-    @classdef.method("send")
-    def method_send(self, space, args_w, block):
-        return space.send(self, "__send__", args_w, block)
-
-    @classdef.method("nil?")
-    def method_nilp(self, space):
-        return space.w_false
-
-    @classdef.method("hash")
-    def method_hash(self, space):
-        return space.newint(compute_identity_hash(self))
-
-    @classdef.method("instance_variable_get", name="str")
-    def method_instance_variable_get(self, space, name):
-        return space.find_instance_var(self, name)
-
-    @classdef.method("instance_variable_set", name="str")
-    @check_frozen()
-    def method_instance_variable_set(self, space, name, w_value):
-        space.set_instance_var(self, name, w_value)
-        return w_value
-
-    @classdef.method("method")
-    def method_method(self, space, w_sym):
-        return space.send(
-            space.send(space.getclass(self), "instance_method", [w_sym]),
-            "bind",
-            [self]
-        )
-
-    @classdef.method("tap")
-    def method_tap(self, space, block):
-        if block is not None:
-            space.invoke_block(block, [self])
-        else:
-            raise space.error(space.w_LocalJumpError, "no block given")
-        return self
 
 
 class W_Object(W_RootObject):


### PR DESCRIPTION
Specs fixed:

BasicObject subclass
- contains Kernel methods when including Kernel
