### PR TITLE
Kernel#methods

### DIFF
--- a/spec/tags/core/kernel/methods_tags.txt
+++ b/spec/tags/core/kernel/methods_tags.txt
@@ -1,18 +1,2 @@
-fails:Kernel#methods returns singleton methods defined by obj.meth
-fails:Kernel#methods returns singleton methods defined in 'class << self'
-fails:Kernel#methods returns private singleton methods defined by obj.meth
-fails:Kernel#methods returns singleton methods defined in 'class << self' when it follows 'private'
 fails:Kernel#methods does not return private singleton methods defined in 'class << self'
 fails:Kernel#methods returns the publicly accessible methods of the object
-fails:Kernel#methods returns the publicly accessible methods in the object, its ancestors and mixed-in modules
-fails:Kernel#methods returns methods added to the metaclass through extend
-fails:Kernel#methods does not return undefined singleton methods defined by obj.meth
-fails:Kernel#methods does not return superclass methods undefined in the object's class
-fails:Kernel#methods does not return superclass methods undefined in a superclass
-fails:Kernel#methods does not return included module methods undefined in the object's class
-fails:Kernel#methods when not passed an argument returns a unique list for an object extended by a module
-fails:Kernel#methods when not passed an argument returns a unique list for a class including a module
-fails:Kernel#methods when not passed an argument returns a unique list for a subclass of a class that includes a module
-fails:Kernel#methods when passed true returns a unique list for an object extended by a module
-fails:Kernel#methods when passed true returns a unique list for a class including a module
-fails:Kernel#methods when passed true returns a unique list for a subclass of a class that includes a module

--- a/topaz/modules/kernel.py
+++ b/topaz/modules/kernel.py
@@ -39,6 +39,12 @@ class Kernel(object):
                 w_cls = w_cls.superclass
         return space.newarray([space.newsymbol(m) for m in methods])
 
+    @moduledef.method("methods", inherit="bool")
+    def method_methods(self, space, inherit=True):
+        w_cls = space.getclass(self)
+
+        return space.newarray([space.newsymbol(m) for m in w_cls.methods(space, inherit)])
+
     @moduledef.method("lambda")
     def function_lambda(self, space, block):
         return block.copy(space, is_lambda=True)

--- a/topaz/objects/classobject.py
+++ b/topaz/objects/classobject.py
@@ -1,7 +1,7 @@
 import copy
 
 from topaz.module import ClassDef
-from topaz.objects.moduleobject import W_ModuleObject
+from topaz.objects.moduleobject import UndefMethod, W_ModuleObject
 from topaz.objects.objectobject import W_Object
 
 
@@ -73,6 +73,17 @@ class W_ClassObject(W_ModuleObject):
         if method is None and self.superclass is not None:
             method = self.superclass.find_method(space, name)
         return method
+
+    def methods(self, space, inherit=True):
+        methods = {}
+        for name in W_ModuleObject.methods(self, space, inherit):
+            methods[name] = None
+        if inherit and self.superclass is not None:
+            for name in self.superclass.methods(space, inherit):
+                method = self._find_method_pure(space, name, self.version)
+                if method is None or not isinstance(method, UndefMethod):
+                    methods[name] = None
+        return methods.keys()
 
     def ancestors(self, include_singleton=True, include_self=True):
         assert include_self

--- a/topaz/objects/moduleobject.py
+++ b/topaz/objects/moduleobject.py
@@ -155,6 +155,20 @@ class W_ModuleObject(W_RootObject):
     def _find_method_pure(self, space, method, version):
         return self.methods_w.get(method, None)
 
+    def methods(self, space, inherit=True):
+        methods = {}
+        for name, method in self.methods_w.iteritems():
+            if not isinstance(method, UndefMethod):
+                methods[name] = None
+
+        if inherit:
+            for w_mod in self.included_modules:
+                for name in w_mod.methods(space, inherit):
+                    method = self._find_method_pure(space, name, self.version)
+                    if method is None or not isinstance(method, UndefMethod):
+                        methods[name] = None
+        return methods.keys()
+
     def set_const(self, space, name, w_obj):
         self.mutated()
         self.constants_w[name] = w_obj


### PR DESCRIPTION
Specs fixed:

Kernel#methods
- returns singleton methods defined by obj.meth
- returns singleton methods defined in 'class << self'
- returns private singleton methods defined by obj.meth
- returns singleton methods defined in 'class << self' when it follows 'private'
- returns the publicly accessible methods in the object, its ancestors and mixed-in modules
- returns methods added to the metaclass through extend
- does not return undefined singleton methods defined by obj.meth
- does not return superclass methods undefined in the object's class
- does not return superclass methods undefined in a superclass
- does not return included module methods undefined in the object's class

Kernel#methods when not passed an argument
- returns a unique list for an object extended by a module
- returns a unique list for a class including a module
- returns a unique list for a subclass of a class that includes a module

Kernel#methods when passed true
- returns a unique list for an object extended by a module
- returns a unique list for a class including a module
- returns a unique list for a subclass of a class that includes a module
