### PR TITLE
Proc#call when self is lambda

### DIFF
--- a/spec/tags/core/proc/call_tags.txt
+++ b/spec/tags/core/proc/call_tags.txt
@@ -1,2 +1,0 @@
-fails:Proc#call on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on missing arguments when self is a lambda
-fails:Proc#call on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on excess arguments when self is a lambda

--- a/spec/tags/core/proc/case_compare_tags.txt
+++ b/spec/tags/core/proc/case_compare_tags.txt
@@ -1,2 +1,0 @@
-fails:Proc#=== on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on missing arguments when self is a lambda
-fails:Proc#=== on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on excess arguments when self is a lambda

--- a/spec/tags/core/proc/element_reference_tags.txt
+++ b/spec/tags/core/proc/element_reference_tags.txt
@@ -1,2 +1,0 @@
-fails:Proc#call on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on missing arguments when self is a lambda
-fails:Proc#call on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on excess arguments when self is a lambda

--- a/spec/tags/core/proc/yield_tags.txt
+++ b/spec/tags/core/proc/yield_tags.txt
@@ -1,2 +1,0 @@
-fails:Proc#yield on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on excess arguments when self is a lambda
-fails:Proc#yield on a Proc created with Kernel#lambda or Kernel#proc raises an ArgumentError on missing arguments when self is a lambda

--- a/topaz/objspace.py
+++ b/topaz/objspace.py
@@ -639,8 +639,11 @@ class ObjectSpace(object):
             block=block.block, parent_interp=block.parent_interp,
             regexp_match_cell=block.regexp_match_cell,
         )
-        if len(bc.arg_pos) != 0 or bc.splat_arg_pos != -1 or bc.block_arg_pos != -1:
-            frame.handle_block_args(self, bc, args_w, block_arg)
+        if block.is_lambda:
+            frame.handle_args(self, bc, args_w, block_arg)
+        else:
+            if len(bc.arg_pos) != 0 or bc.splat_arg_pos != -1 or bc.block_arg_pos != -1:
+                frame.handle_block_args(self, bc, args_w, block_arg)
         assert len(block.cells) == len(bc.freevars)
         for i in xrange(len(bc.freevars)):
             frame.cells[len(bc.cellvars) + i] = block.cells[i]


### PR DESCRIPTION
Specs fixed:

Proc#call on a Proc created with Kernel#lambda or Kernel#proc
- raises an ArgumentError on excess arguments when self is a lambda
- raises an ArgumentError on missing arguments when self is a lambda

Proc#=== on a Proc created with Kernel#lambda or Kernel#proc
- raises an ArgumentError on excess arguments when self is a lambda
- raises an ArgumentError on missing arguments when self is a lambda

Proc#[] on a Proc created with Kernel#lambda or Kernel#proc
- raises an ArgumentError on excess arguments when self is a lambda
- raises an ArgumentError on missing arguments when self is a lambda

Proc#yield on a Proc created with Kernel#lambda or Kernel#proc
- raises an ArgumentError on excess arguments when self is a lambda
- raises an ArgumentError on missing arguments when self is a lambda
