### PR TITLE
Hash#compare_by_identity

### DIFF
--- a/topaz/objects/hashobject.py
+++ b/topaz/objects/hashobject.py
@@ -66,7 +66,9 @@ class W_HashObject(W_Object):
     @check_frozen()
     def method_compare_by_identity(self, space):
         self.compare_by_identity = True
-        self.contents.set_eq_func(space.equal_w)
+        new_contents = OrderedDict(None, None)
+        new_contents.update(self.contents)
+        self.contents = new_contents
         return self
 
     @classdef.method("compare_by_identity?")

--- a/topaz/objspace.py
+++ b/topaz/objspace.py
@@ -671,9 +671,6 @@ class ObjectSpace(object):
     def eq_w(self, w_obj1, w_obj2):
         return self.is_true(self.send(w_obj2, "eql?", [w_obj1]))
 
-    def equal_w(self, w_obj1, w_obj2):
-        return (w_obj2 is w_obj1)
-
     def register_exit_handler(self, w_proc):
         self.exit_handlers_w.append(w_proc)
 

--- a/topaz/utils/ordereddict.py
+++ b/topaz/utils/ordereddict.py
@@ -69,9 +69,6 @@ class OrderedDict(object):
     def clear(self):
         self.contents.clear()
 
-    def set_eq_func(self, new_eq_func):
-        self.eq_func = new_eq_func
-
 
 class DictKey(object):
     def __init__(self, d, key):


### PR DESCRIPTION
untagged with untranslated

translate with error:

```
[translation:ERROR]  AnnotatorError: ("Cannot find attribute 'set_eq_func' on SomeOrderedDict(bookkeeper=<rpython.annotator.bookkeeper.Bookkeeper object at 0x44dee90>, dictdef=<{SomeImpossibleValue(): SomeImpossibleValue()}>)", <
[translation:ERROR]  v1 = getattr(v0, ('set_eq_func'))
[translation:ERROR] In <FunctionGraph of (topaz.objects.hashobject:65)method_set_default_proc at 0x77c48d0>:
[translation:ERROR] Happened at file topaz/objects/hashobject.py line 70
[translation:ERROR]
[translation:ERROR] ==>         self.contents.set_eq_func(space.equal_w)
```
