### PR TITLE
Implemented "Fixnum#** overflows the answer to a bignum transparantly"-spec

### DIFF
--- a/spec/tags/core/fixnum/exponent_tags.txt
+++ b/spec/tags/core/fixnum/exponent_tags.txt
@@ -1,5 +1,4 @@
 fails:Fixnum#** returns self raised to the given power
-fails:Fixnum#** overflows the answer to a bignum transparantly
 fails:Fixnum#** raises negative numbers to the given power
 fails:Fixnum#** can raise -1 to a Bignum safely
 fails:switches to a Float when the number is too big

--- a/topaz/objects/intobject.py
+++ b/topaz/objects/intobject.py
@@ -212,7 +212,7 @@ class W_FixnumObject(W_RootObject):
             except OverflowError:
                 return space.send(
                     space.newbigint_fromint(self.intvalue), "**",
-                    [space.newint(exp)]
+                    [w_other]
                 )
             return space.newint(ix)
         else:


### PR DESCRIPTION
Stuff like 2**63, where the base and the exponent are not big but the result is, works now.

The following problem occured while untagging:
The "Fixnum#*\* switches to a Float when the number is too big"-spec started looping forever. I had to force it to fail before it could start looping so that my "invoke specs.untag" call could terminate (the option "-e overflows" for just selecting the spec I was interested in worked for specs.run but not for specs.untag). I'm assuming the problem comes from the pow method of rbigint (in rpython.rlib) but I'm not entirely sure.
