### PR TITLE
Fix Time#usec to actually pass the specs

### DIFF
--- a/lib-topaz/time.rb
+++ b/lib-topaz/time.rb
@@ -1,7 +1,6 @@
 class Time
   def usec
-    float = self.to_f
-    (float - float.floor) * 1e6
+    (self.to_f * 1e6 % 1e6).floor
   end
 
   def tv_usec

--- a/spec/tags/core/time/usec_tags.txt
+++ b/spec/tags/core/time/usec_tags.txt
@@ -1,6 +1,3 @@
-fails:Time#usec returns the microseconds part of a Time constructed with an Integer number of microseconds
-fails:Time#usec returns the microseconds part of a Time constructed with an Float number of microseconds > 1
-fails:Time#usec returns 0 for a Time constructed with an Float number of microseconds < 1
 fails:Time#usec returns the microseconds part of a Time constructed with a Rational number of seconds
 fails:Time#usec returns the microseconds part of a Time constructed with an Rational number of microseconds > 1
 fails:Time#usec returns 0 for a Time constructed with an Rational number of microseconds < 1


### PR DESCRIPTION
was actually returning the microseconds wrong, also the new implementation should have less of a rounding error
