### PR TITLE
String.chomp maintains trailing carriage return

### DIFF
--- a/spec/tags/core/string/chomp_tags.txt
+++ b/spec/tags/core/string/chomp_tags.txt
@@ -1,6 +1,4 @@
-fails:String#chomp when passed '' does not remove a final carriage return
 fails:String#chomp! when passed nil returns nil
 fails:String#chomp! when passed nil returns nil when self is empty
-fails:String#chomp! when passed '' does not remove a final carriage return
 fails:String#chomp removes the final carriage return, newline from a non-ASCII String
 fails:String#chomp! removes the final carriage return, newline from a non-ASCII String

--- a/tests/objects/test_stringobject.py
+++ b/tests/objects/test_stringobject.py
@@ -433,11 +433,14 @@ class TestStringObject(BaseTopazTest):
         assert space.str_w(space.execute('return "hello\\r\\n".chomp')) == "hello"
         assert space.str_w(space.execute('return "hello\\n\\r".chomp')) == "hello"
         assert space.str_w(space.execute('return "hello\\r".chomp')) == "hello"
+        assert space.str_w(space.execute('return "hello\\r".chomp("")')) == "hello\r"
         assert space.str_w(space.execute('return "hello \\n there".chomp')) == "hello \n there"
         assert space.str_w(space.execute('return "hello".chomp("llo")')) == "he"
         w_res = space.execute('return "hello".chomp!')
         assert w_res is space.w_nil
         w_res = space.execute('return "".chomp!')
+        assert w_res is space.w_nil
+        w_res = space.execute('return "abc\\r".chomp!("")')
         assert w_res is space.w_nil
 
     def test_chop(self, space):

--- a/topaz/objects/stringobject.py
+++ b/topaz/objects/stringobject.py
@@ -223,9 +223,10 @@ class MutableStringStrategy(StringStrategy):
         elif newline is not None and len(newline) == 0:
             ch = storage[-1]
             i = len(storage) - 1
-            while i >= 1 and ch in linebreaks:
-                i -= 1
-                ch = storage[i]
+            if ch != "\r":
+                while i >= 1 and ch in linebreaks:
+                    i -= 1
+                    ch = storage[i]
             if i < len(storage) - 1:
                 i += 1
                 changed = True


### PR DESCRIPTION
baby steps - let me know if this change looks good.
