### PR TITLE
Float formatting

### DIFF
--- a/tests/objects/test_floatobject.py
+++ b/tests/objects/test_floatobject.py
@@ -82,9 +82,6 @@ class TestFloatObject(BaseTopazTest):
         assert space.str_w(w_res) == "0.0001"
         w_res = space.execute("return 0.00001.to_s")
         assert space.str_w(w_res) == "1.0e-05"
-        
-        
-        w_res = space.execute
 
     def test_to_i(self, space):
         w_res = space.execute("return [1.1.to_i, 1.1.to_int]")

--- a/topaz/objects/floatobject.py
+++ b/topaz/objects/floatobject.py
@@ -5,7 +5,7 @@ import sys
 from rpython.rlib.objectmodel import compute_hash
 from rpython.rlib.rarithmetic import ovfcheck_float_to_int
 from rpython.rlib.rbigint import rbigint
-from rpython.rlib.rfloat import (formatd, DTSF_ADD_DOT_0, DTSF_STR_PRECISION,
+from rpython.rlib.rfloat import (formatd, DTSF_ADD_DOT_0,
     NAN, INFINITY, isfinite, round_away)
 
 from topaz.error import RubyError
@@ -90,12 +90,12 @@ class W_FloatObject(W_RootObject):
                     if len(exponent_str) == 1:
                         exponent_str = "0" + exponent_str
 
-                    float_string = (number 
-                                    + "." + decimal_places 
+                    float_string = (number
+                                    + "." + decimal_places
                                     + "e-" + exponent_str)
                 elif exponent > 0:
-                    # We have to move the decimal separator 
-                    # exponent steps to the right 
+                    # We have to move the decimal separator
+                    # exponent steps to the right
                     if len(decimal_places) < exponent:
                         zeroes = "0" * (exponent - len(decimal_places))
                         decimal_places = (decimal_places + zeroes)


### PR DESCRIPTION
Proposal to fix #779. Float#to_s should create the closest string representation of the float which itself creates the float again. The RPython float to string mode "r" allows this and only needed some polishing to match the formatting of Ruby 1.9.3
