### PR TITLE
Guard {Fixnum|Float}#frozen? from segfault and to be compatible with Ruby 1.9.3 behaviors

### DIFF
--- a/tests/objects/test_floatobject.py
+++ b/tests/objects/test_floatobject.py
@@ -213,3 +213,29 @@ class TestFloatObject(BaseTopazTest):
         assert w_res is space.w_false
         w_res = space.execute("return Float::NAN.nan?")
         assert w_res is space.w_true
+
+    def test_ivar(self, space):
+        w_res = space.execute("""
+        class Float
+          def set; @foo = true; end
+          def get; @foo; end
+        end
+        float = 0.1
+        res = [float.get]
+        float.set
+        res << float.get
+        res << 0.2.get
+        return res
+        """)
+        assert self.unwrap(space, w_res) == [None, True, None]
+
+    def test_freeze(self, space):
+        w_res = space.execute("""
+        float = 0.1
+        res = [float.frozen?]
+        float.freeze
+        res << float.frozen?
+        res << 0.2.frozen?
+        return res
+        """)
+        assert self.unwrap(space, w_res) == [False, True, False]

--- a/tests/objects/test_intobject.py
+++ b/tests/objects/test_intobject.py
@@ -230,6 +230,16 @@ class TestFixnumObject(BaseTopazTest):
         assert x == y == -1
         assert z is None
 
+    def test_freeze(self, space):
+        w_res = space.execute("""
+        res = [1.frozen?]
+        1.freeze
+        res << 1.frozen?
+        res << 2.frozen?
+        return res
+        """)
+        assert self.unwrap(space, w_res) == [False, True, False]
+
     def test_succ(self, space):
         w_res = space.execute("return -1.succ")
         assert self.unwrap(space, w_res) == 0

--- a/topaz/objects/floatobject.py
+++ b/topaz/objects/floatobject.py
@@ -15,6 +15,18 @@ from topaz.objects.objectobject import W_RootObject
 from topaz.objects.numericobject import W_NumericObject
 
 
+class FloatStorage(object):
+    def __init__(self, space):
+        self.storages = {}
+
+    def get_or_create(self, space, floatvalue):
+        try:
+            storage = self.storages[floatvalue]
+        except KeyError:
+            self.storages[floatvalue] = storage = space.send(space.w_object, "new")
+        return storage
+
+
 class W_FloatObject(W_RootObject):
     _immutable_fields_ = ["floatvalue"]
 
@@ -61,6 +73,26 @@ class W_FloatObject(W_RootObject):
         space.set_const(w_cls, "MAX_EXP", space.newint(sys.float_info.max_exp))
         space.set_const(w_cls, "MIN_EXP", space.newint(sys.float_info.min_exp))
         space.set_const(w_cls, "RADIX", space.newint(sys.float_info.radix))
+
+    def find_instance_var(self, space, name):
+        storage = space.fromcache(FloatStorage).get_or_create(space, self.floatvalue)
+        return storage.find_instance_var(space, name)
+
+    def set_instance_var(self, space, name, w_value):
+        storage = space.fromcache(FloatStorage).get_or_create(space, self.floatvalue)
+        storage.set_instance_var(space, name, w_value)
+
+    def set_flag(self, space, name):
+        storage = space.fromcache(FloatStorage).get_or_create(space, self.floatvalue)
+        storage.set_flag(space, name)
+
+    def unset_flag(self, space, name):
+        storage = space.fromcache(FloatStorage).get_or_create(space, self.floatvalue)
+        storage.unset_flag(space, name)
+
+    def get_flag(self, space, name):
+        storage = space.fromcache(FloatStorage).get_or_create(space, self.floatvalue)
+        return storage.get_flag(space, name)
 
     @classdef.method("inspect")
     @classdef.method("to_s")

--- a/topaz/objects/intobject.py
+++ b/topaz/objects/intobject.py
@@ -74,6 +74,18 @@ class W_FixnumObject(W_RootObject):
         storage = space.fromcache(FixnumStorage).get_or_create(space, self.intvalue)
         storage.set_instance_var(space, name, w_value)
 
+    def set_flag(self, space, name):
+        storage = space.fromcache(FixnumStorage).get_or_create(space, self.intvalue)
+        storage.set_flag(space, name)
+
+    def unset_flag(self, space, name):
+        storage = space.fromcache(FixnumStorage).get_or_create(space, self.intvalue)
+        storage.unset_flag(space, name)
+
+    def get_flag(self, space, name):
+        storage = space.fromcache(FixnumStorage).get_or_create(space, self.intvalue)
+        return storage.get_flag(space, name)
+
     @classdef.method("extend")
     @classdef.method("singleton_class")
     def method_singleton_class(self, space):


### PR DESCRIPTION
ref: https://github.com/topazproject/topaz/pull/845

```
$ PYTHONPATH=../pypy python ./bin/topaz_untranslated.py -e 'f = 0.1; p f.frozen?; f.freeze; p f.frozen?'
false
true
```

```
$ PYTHONPATH=../pypy python ./bin/topaz_untranslated.py -e 'f 1; p f.frozen?; f.freeze; p f.frozen?'
false
true
```

@alex How about like this?