### PR TITLE
Guard Kernel#sleep with nil or String arguments from segfault

### DIFF
--- a/tests/modules/test_kernel.py
+++ b/tests/modules/test_kernel.py
@@ -217,6 +217,13 @@ class TestKernel(BaseTopazTest):
         assert space.int_w(w_res) == 0
         assert time.time() - now >= 0.002
 
+        with self.raises(space, "TypeError"):
+            space.execute("return sleep nil")
+        with self.raises(space, "TypeError"):
+            space.execute("return sleep '1'")
+        with self.raises(space, "TypeError"):
+            space.execute("return sleep Object.new")
+
     def test_trust(self, space):
         w_res = space.execute("return 'a'.untrusted?")
         assert self.unwrap(space, w_res) is False

--- a/topaz/modules/kernel.py
+++ b/topaz/modules/kernel.py
@@ -341,6 +341,10 @@ class Kernel(object):
     def method_sleep(self, space, w_duration=None):
         if w_duration is None:
             raise space.error(space.w_NotImplementedError)
+        elif w_duration is space.w_nil:
+            raise space.error(space.w_TypeError, "can't convert nil into time interval")
+        elif space.is_kind_of(w_duration, space.w_string):
+            raise space.error(space.w_TypeError, "can't convert String into time interval")
         start = time.time()
         time.sleep(space.float_w(w_duration))
         return space.newint(int(round_double(time.time() - start, 0)))

--- a/topaz/modules/kernel.py
+++ b/topaz/modules/kernel.py
@@ -341,12 +341,10 @@ class Kernel(object):
     def method_sleep(self, space, w_duration=None):
         if w_duration is None:
             raise space.error(space.w_NotImplementedError)
-        elif w_duration is space.w_nil:
-            raise space.error(space.w_TypeError, "can't convert nil into time interval")
         elif space.is_kind_of(w_duration, space.w_string):
             raise space.error(space.w_TypeError, "can't convert String into time interval")
         start = time.time()
-        time.sleep(space.float_w(w_duration))
+        time.sleep(Coerce.float(space, w_duration))
         return space.newint(int(round_double(time.time() - start, 0)))
 
     @moduledef.method("initialize_clone")


### PR DESCRIPTION
Guard from below.
```shell
$ bin/topaz -e 'sleep(nil)'
[1]    45984 segmentation fault  bin/topaz -e 'sleep(nil)'

$ bin/topaz -e 'sleep(" ")'
[1]    46750 segmentation fault  bin/topaz -e 'sleep(" ")'
```