### PR TITLE
Guard Process.kill from segfault when PIDs contain nil

### DIFF
--- a/topaz/modules/process.py
+++ b/topaz/modules/process.py
@@ -113,14 +113,14 @@ class Process(object):
 
         if sig < 0:
             for w_arg in args_w:
-                pid = space.int_w(w_arg)
+                pid = Coerce.int(space, w_arg)
                 try:
                     killpg(pid, -sig)
                 except OSError as e:
                     raise error_for_oserror(space, e)
         else:
             for w_arg in args_w:
-                pid = space.int_w(w_arg)
+                pid = Coerce.int(space, w_arg)
                 try:
                     kill(pid, sig)
                 except OSError as e:


### PR DESCRIPTION
```shell
$ bin/topaz -e 'Process.kill :TERM, nil'
[1]    48092 segmentation fault  bin/topaz -e 'Process.kill :TERM, nil'
```