### PR TITLE
Guard uninitialized Regexp#match from segfault

### DIFF
--- a/tests/objects/test_regexpobject.py
+++ b/tests/objects/test_regexpobject.py
@@ -140,6 +140,12 @@ class TestRegexpObject(BaseTopazTest):
         w_res = space.execute("return Regexp.new(/abc/).source")
         assert space.str_w(w_res) == "abc"
 
+    def test_allocate(self, space):
+        with self.raises(space, "TypeError", "uninitialized Regexp"):
+            space.execute("Regexp.allocate.source")
+        with self.raises(space, "TypeError", "uninitialized Regexp"):
+            space.execute("Regexp.allocate.match ''")
+
     def test_size(self, space):
         w_res = space.execute("""
         /(a)(b)(c)/ =~ "hey hey, abc, hey hey"

--- a/topaz/objects/regexpobject.py
+++ b/topaz/objects/regexpobject.py
@@ -51,6 +51,7 @@ class W_RegexpObject(W_Object):
 
     def __init__(self, space, source, flags):
         W_Object.__init__(self, space)
+        self.source = None
         self.set_source(space, source, flags)
 
     @classdef.setup_class
@@ -130,7 +131,7 @@ class W_RegexpObject(W_Object):
             return space.send(w_match, "post_match")
 
     def _check_initialized(self, space):
-        if not hasattr(self, "source") or self.source is None:
+        if self.source is None:
             raise space.error(space.w_TypeError, "uninitialized Regexp")
 
     def set_source(self, space, source, flags):

--- a/topaz/objects/regexpobject.py
+++ b/topaz/objects/regexpobject.py
@@ -130,7 +130,7 @@ class W_RegexpObject(W_Object):
             return space.send(w_match, "post_match")
 
     def _check_initialized(self, space):
-        if self.source is None:
+        if not hasattr(self, "source") or self.source is None:
             raise space.error(space.w_TypeError, "uninitialized Regexp")
 
     def set_source(self, space, source, flags):
@@ -219,6 +219,7 @@ class W_RegexpObject(W_Object):
 
     @classdef.method("match")
     def method_match(self, space, w_s, w_offset=None):
+        self._check_initialized(space)
         if w_s is space.w_nil:
             return space.w_nil
         s = Coerce.str(space, w_s)


### PR DESCRIPTION
```shel
$ bin/topaz -e 'Regexp.allocate.match ""'
[1]    1202 segmentation fault  bin/topaz -e 'Regexp.allocate.match ""'
```