### PR TITLE
String#sub without replacement and block should raise an ArgumentError

### DIFF
--- a/tests/objects/test_stringobject.py
+++ b/tests/objects/test_stringobject.py
@@ -538,6 +538,8 @@ class TestStringObject(BaseTopazTest):
         return 'helloo'.sub("l", Hash.new { |h, k| replacements.pop() })
         """)
         assert space.str_w(w_res) == "he2loo"
+        with self.raises(space, "ArgumentError"):
+            space.execute("'string'.sub(/regex/)")
 
     def test_succ(self, space):
         w_res = space.execute('return "abcd".succ')

--- a/topaz/objects/stringobject.py
+++ b/topaz/objects/stringobject.py
@@ -1080,6 +1080,8 @@ class W_StringObject(W_Object):
 
     @classdef.method("sub")
     def method_sub(self, space, w_pattern, w_replacement=None, block=None):
+        if w_replacement is None and block is None:
+            raise space.error(space.w_ArgumentError, "wrong number of arguments")
         return self.gsub_main(space, w_pattern, w_replacement, block, first_only=True)
 
     def gsub_main(self, space, w_pattern, w_replacement, block, first_only):


### PR DESCRIPTION
```shell
$ ruby -v
ruby 1.9.3p551 (2014-11-13) [x86_64-darwin14.5.0]
$ ruby -e '"abca".sub(/a/)'
-e:1:in `sub': wrong number of arguments (1 for 1..2) (ArgumentError)
```

```shell
$ bin/topaz -e '"abca".sub(/a/)'
Fatal RPython error: NotImplementedError
[1]    79162 abort      bin/topaz -e '"abca".sub(/a/)'
```