### PR TITLE
Guard `defined?` from segfault with default value

### DIFF
--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -1105,6 +1105,10 @@ class TestInterpreter(BaseTopazTest):
         """)
         assert space.str_w(w_res) == "expression"
         w_res = space.execute("""
+        return [defined?(while x do y end), defined?(return), defined?(__FILE__)]
+        """)
+        assert self.unwrap(space, w_res) == ["expression", "expression", "expression"]
+        w_res = space.execute("""
         $abc = 3
         return [defined?($abc), defined?($abd)]
         """)

--- a/topaz/ast.py
+++ b/topaz/ast.py
@@ -21,6 +21,9 @@ class BaseNode(object):
         else:
             raise NotImplementedError(type(self).__name__)
 
+    def compile_defined(self, ctx):
+        ConstantString("expression").compile(ctx)
+
 
 class Node(BaseNode):
     _attrs_ = ["lineno"]


### PR DESCRIPTION
`defined?` with some code segfaults.

topaz (ruby-1.9.3p125) (git rev 6937882) [x86_64-darwin]
```zsh
☻  bin/topaz -e 'p defined?(next)'
[1]    69483 segmentation fault  bin/topaz -e 'p defined?(next)'
```


And below. (noticed from https://github.com/topazproject/topaz/pull/845)
```ruby
defined?(while x do y end)
defined?(until x do y end)
defined?(break)
defined?(next)
defined?(return)
defined?(__FILE__)
```