### PR TITLE
Guard Kernel.#catch without block from segfault

### DIFF
--- a/spec/tags/core/kernel/catch_tags.txt
+++ b/spec/tags/core/kernel/catch_tags.txt
@@ -3,7 +3,6 @@ fails:Kernel.catch raises an ArgumentError if a Symbol is thrown for a String ca
 fails:Kernel.catch raises an ArgumentError if a String with different identity is thrown
 fails:Kernel.catch accepts an object as an argument
 fails:Kernel.catch yields an object when called without arguments
-fails:Kernel.catch raises LocalJumpError if no block is given
 fails:Kernel.catch when nested catches across invocation boundaries
 fails:Kernel.catch when nested catches in the nested invocation with the same key object
 fails:Kernel#catch is a private method

--- a/topaz/modules/kernel.py
+++ b/topaz/modules/kernel.py
@@ -435,6 +435,8 @@ class Kernel(object):
 
     @moduledef.method("catch", name="symbol")
     def method_catch(self, space, name, block):
+        if block is None:
+            raise space.error(space.w_LocalJumpError, "no block given")
         from topaz.interpreter import Throw
         with space.getexecutioncontext().catch_block(name):
             try:


### PR DESCRIPTION
```zsh
☻  bin/topaz -e 'catch :s'
[1]    36899 segmentation fault  bin/topaz -e 'catch :s'
```

last of untranslated
```text
File "topaz/modules/kernel.py", line 441, in method_catch
  return space.invoke_block(block, [])
File "topaz/objspace.py", line 648, in invoke_block
  bc = block.bytecode
AttributeError: 'NoneType' object has no attribute 'bytecode'
```

ruby-1.9.3p551
```zsh
☻  ruby -e 'catch :s'
-e:1:in `catch': no block given (LocalJumpError)
```