### PR TITLE
Guard sort with unexpected block from segfault

### DIFF
--- a/tests/objects/test_arrayobject.py
+++ b/tests/objects/test_arrayobject.py
@@ -368,7 +368,7 @@ class TestArrayObject(BaseTopazTest):
         return a.object_id == b.object_id, a, b
         """)
         assert self.unwrap(space, w_res) == [True, [3, 2, 1], [3, 2, 1]]
-        with self.raises(space, "TypeError"):
+        with self.raises(space, "NoMethodError"):
             space.execute("[0, 1].sort{ |n, m| BasicObject.new }")
         with self.raises(space, "ArgumentError", "comparison of Array with Object failed"):
             space.execute("[Object.new, []].sort")

--- a/tests/objects/test_arrayobject.py
+++ b/tests/objects/test_arrayobject.py
@@ -368,6 +368,8 @@ class TestArrayObject(BaseTopazTest):
         return a.object_id == b.object_id, a, b
         """)
         assert self.unwrap(space, w_res) == [True, [3, 2, 1], [3, 2, 1]]
+        with self.raises(space, "TypeError"):
+            space.execute("[0, 1].sort{ |n, m| BasicObject.new }")
         with self.raises(space, "ArgumentError", "comparison of Array with Object failed"):
             space.execute("[Object.new, []].sort")
 

--- a/topaz/objects/arrayobject.py
+++ b/topaz/objects/arrayobject.py
@@ -26,7 +26,7 @@ class RubySorter(BaseRubySorter):
         if self.space.is_kind_of(w_cmp_res, self.space.w_bignum):
             return self.space.bigint_w(w_cmp_res).lt(rbigint.fromint(0))
         else:
-            return Coerce.int(self.space, w_cmp_res) < 0
+            return Coerce.bool(self.space, self.space.send(w_cmp_res, "<", [self.space.newint(0)]))
 
 
 class RubySortBy(BaseRubySortBy):

--- a/topaz/objects/arrayobject.py
+++ b/topaz/objects/arrayobject.py
@@ -26,7 +26,7 @@ class RubySorter(BaseRubySorter):
         if self.space.is_kind_of(w_cmp_res, self.space.w_bignum):
             return self.space.bigint_w(w_cmp_res).lt(rbigint.fromint(0))
         else:
-            return self.space.int_w(w_cmp_res) < 0
+            return Coerce.int(self.space, w_cmp_res) < 0
 
 
 class RubySortBy(BaseRubySortBy):


### PR DESCRIPTION
```zsh
☻  bin/topaz -e '[0, 1].sort{ |n, m| BasicObject.new }'
[1]    53408 segmentation fault  bin/topaz -e '[0, 1].sort{ |n, m| BasicObject.new }'
```

last of untranslated
```text
File "topaz/objects/arrayobject.py", line 29, in lt
  return self.space.int_w(w_cmp_res) < 0
File "topaz/objspace.py", line 462, in int_w
  return w_obj.int_w(self)
AttributeError: 'W_Object' object has no attribute 'int_w'
```

ruby-1.9.3p551
```zsh
☻  ruby -e '[0, 1].sort{ |n, m| BasicObject.new }'
-e:1:in `sort': undefined method `>' for #<BasicObject:0x007fe1e91033f8> (NoMethodError)
```