### PR TITLE
Fixed a bug in lexical const lookup

### DIFF
--- a/topaz/objspace.py
+++ b/topaz/objspace.py
@@ -617,7 +617,7 @@ class ObjectSpace(object):
         if lexical_scope is not None:
             w_mod = lexical_scope.w_mod
             while w_mod is not None:
-                object_seen = w_mod is self.w_object
+                object_seen = object_seen or w_mod is self.w_object
                 # BasicObject was our starting point, do not use Object
                 # as fallback
                 if w_mod is self.w_basicobject and not object_seen:


### PR DESCRIPTION
I actually have no idea what the bug is, but the handling of `object_seen` looks "obviously wrong" to me.  It will never be the case that we hit `fallback_scope = None` because that currently requires `w_mod is self.w_basicobject` and `object_seen`. `object_seen = w_mod is self.w_object`. By substitution that means `w_mod is self.w_basicobject and w_mod is self.w_object` which is trivially false.

The fix I propose here makes intuitive sense to me, but I haven't event attempted to run this code.